### PR TITLE
Option to use personal access token over read:org permission on user's access token

### DIFF
--- a/src/main/java/cd/go/authorization/github/GitHubAuthorizer.java
+++ b/src/main/java/cd/go/authorization/github/GitHubAuthorizer.java
@@ -16,9 +16,10 @@
 
 package cd.go.authorization.github;
 
+import cd.go.authorization.github.models.AuthConfig;
+import cd.go.authorization.github.models.LoggedInUserInfo;
 import cd.go.authorization.github.models.Role;
 import cd.go.authorization.github.models.User;
-import org.kohsuke.github.GitHub;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -38,7 +39,8 @@ public class GitHubAuthorizer {
         this.membershipChecker = membershipChecker;
     }
 
-    public List<String> authorize(User user, GitHub gitHub, List<Role> roles) throws IOException {
+    public List<String> authorize(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, List<Role> roles) throws IOException {
+        final User user = loggedInUserInfo.getUser();
         final List<String> assignedRoles = new ArrayList<>();
 
         if (roles.isEmpty()) {
@@ -54,12 +56,12 @@ public class GitHubAuthorizer {
                 assignedRoles.add(role.name());
             }
 
-            if (membershipChecker.isAMemberOfAtLeastOneOrganization(gitHub, role.roleConfiguration().organizations())) {
+            if (membershipChecker.isAMemberOfAtLeastOneOrganization(loggedInUserInfo, authConfig, role.roleConfiguration().organizations())) {
                 LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one organization.", role.name(), user.username()));
                 assignedRoles.add(role.name());
             }
 
-            if (membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(gitHub, role.roleConfiguration().teams())) {
+            if (membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(loggedInUserInfo, authConfig, role.roleConfiguration().teams())) {
                 LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one team of the organization.", role.name(), user.username()));
                 assignedRoles.add(role.name());
             }

--- a/src/main/java/cd/go/authorization/github/GitHubClientBuilder.java
+++ b/src/main/java/cd/go/authorization/github/GitHubClientBuilder.java
@@ -16,7 +16,6 @@
 
 package cd.go.authorization.github;
 
-import cd.go.authorization.github.models.AuthConfig;
 import cd.go.authorization.github.models.AuthenticateWith;
 import cd.go.authorization.github.models.GitHubConfiguration;
 import org.kohsuke.github.GitHub;
@@ -27,8 +26,8 @@ import static cd.go.authorization.github.GitHubPlugin.LOG;
 
 public class GitHubClientBuilder {
 
-    public GitHub build(String usersAccessToken, AuthConfig authConfig) throws IOException {
-        return createGitHub(usersAccessToken, authConfig.gitHubConfiguration());
+    public GitHub build(String usersAccessToken, GitHubConfiguration gitHubConfiguration) throws IOException {
+        return createGitHub(usersAccessToken, gitHubConfiguration);
     }
 
     private GitHub createGitHub(String accessToken, GitHubConfiguration gitHubConfiguration) throws IOException {

--- a/src/main/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutor.java
@@ -19,7 +19,10 @@ package cd.go.authorization.github.executors;
 
 import cd.go.authorization.github.annotation.MetadataValidator;
 import cd.go.authorization.github.annotation.ValidationResult;
+import cd.go.authorization.github.models.AuthenticateWith;
+import cd.go.authorization.github.models.GitHubConfiguration;
 import cd.go.authorization.github.requests.AuthConfigValidateRequest;
+import cd.go.authorization.github.utils.Util;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 
@@ -32,7 +35,17 @@ public class AuthConfigValidateRequestExecutor implements RequestExecutor {
     }
 
     public GoPluginApiResponse execute() throws Exception {
-        final ValidationResult validationResult = new MetadataValidator().validate(request.githubConfiguration());
+        final GitHubConfiguration gitHubConfiguration = request.githubConfiguration();
+        final ValidationResult validationResult = new MetadataValidator().validate(gitHubConfiguration);
+
+        if (gitHubConfiguration.authenticateWith() == AuthenticateWith.GITHUB_ENTERPRISE && Util.isBlank(gitHubConfiguration.gitHubEnterpriseUrl())) {
+            validationResult.addError("GitHubEnterpriseUrl", "GitHubEnterpriseUrl must not be blank.");
+        }
+
+        if (gitHubConfiguration.authorizeUsingPersonalAccessToken() && Util.isBlank(gitHubConfiguration.personalAccessToken())) {
+            validationResult.addError("PersonalAccessToken", "PersonalAccessToken must not be blank.");
+        }
+
         return DefaultGoPluginApiResponse.success(validationResult.toJSON());
     }
 }

--- a/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
@@ -21,11 +21,10 @@ import cd.go.authorization.github.GitHubAuthorizer;
 import cd.go.authorization.github.GitHubClientBuilder;
 import cd.go.authorization.github.exceptions.NoAuthorizationConfigurationException;
 import cd.go.authorization.github.models.AuthConfig;
-import cd.go.authorization.github.models.User;
+import cd.go.authorization.github.models.LoggedInUserInfo;
 import cd.go.authorization.github.requests.UserAuthenticationRequest;
 import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
-import org.kohsuke.github.GitHub;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -57,13 +56,12 @@ public class UserAuthenticationRequestExecutor implements RequestExecutor {
         }
 
         final AuthConfig authConfig = request.authConfigs().get(0);
-        final GitHub gitHub = providerManager.build(request.tokenInfo().accessToken(), authConfig);
-        final User user = gitHubAuthenticator.authenticate(gitHub, authConfig);
+        final LoggedInUserInfo loggedInUserInfo = gitHubAuthenticator.authenticate(request.tokenInfo(), authConfig);
 
         Map<String, Object> userMap = new HashMap<>();
-        if (user != null) {
-            userMap.put("user", user);
-            userMap.put("roles", gitHubAuthorizer.authorize(user, gitHub, request.roles()));
+        if (loggedInUserInfo != null) {
+            userMap.put("user", loggedInUserInfo.getUser());
+            userMap.put("roles", gitHubAuthorizer.authorize(loggedInUserInfo, authConfig, request.roles()));
         }
 
         DefaultGoPluginApiResponse response = new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, GSON.toJson(userMap));

--- a/src/main/java/cd/go/authorization/github/models/LoggedInUserInfo.java
+++ b/src/main/java/cd/go/authorization/github/models/LoggedInUserInfo.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.models;
+
+import org.kohsuke.github.GHMyself;
+import org.kohsuke.github.GitHub;
+
+import java.io.IOException;
+
+public class LoggedInUserInfo {
+    private final GitHub gitHub;
+    private final GHMyself gitHubUser;
+    private final User user;
+
+    public LoggedInUserInfo(GitHub gitHub) throws IOException {
+        this.gitHub = gitHub;
+        gitHubUser = gitHub.getMyself();
+        user = new User(gitHubUser.getLogin(), gitHubUser.getName(), gitHubUser.getEmail());
+    }
+
+    public GitHub getGitHub() {
+        return gitHub;
+    }
+
+    public GHMyself getGitHubUser() {
+        return gitHubUser;
+    }
+
+    public User getUser() {
+        return user;
+    }
+}

--- a/src/main/resources/auth-config.template.html
+++ b/src/main/resources/auth-config.template.html
@@ -138,6 +138,33 @@
         <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientSecret].$error.server}" ng-show="GOINPUTNAME[ClientSecret].$error.server">{{GOINPUTNAME[ClientSecret].$error.server}}</span>
     </div>
 
+    <div class="form_item_block row" style="padding-top: 10px" ng-init="AuthorizeUsing = (AuthorizeUsing || 'PersonalAccessToken')">
+        <div class="columns small-3 medium-2 larger-2">
+            <label ng-class="{'is-invalid-label': GOINPUTNAME[AuthorizeUsing].$error.server}">Authorize user using</label>
+        </div>
+        <div class="columns small-9 medium-10 larger-10">
+            <input value="PersonalAccessToken" type="radio" ng-model="AuthorizeUsing" id="personal-access-token" ng-checked="AuthorizeUsing == 'PersonalAccessToken'"/>
+            <label for="personal-access-token">Personal Access Token</label>
+
+            <input value="UserAccessToken" type="radio" ng-model="AuthorizeUsing" ng-checked="AuthorizeUsing == 'UserAccessToken'" id="users-access-token" ng-click="PersonalAccessToken = ''"/>
+            <label for="users-access-token">User's Access Token</label>
+            <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AuthorizeUsing].$error.server}" ng-show="GOINPUTNAME[AuthorizeUsing].$error.server">{{GOINPUTNAME[AuthorizeUsing].$error.server}}</span>
+        </div>
+
+    </div>
+
+    <div class="form_item_block" ng-show="AuthorizeUsing == 'PersonalAccessToken'" ng-init="PersonalAccessToken = (PersonalAccessToken || '')">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[PersonalAccessToken].$error.server}">Personal Access Token:<span class='asterix'>*</span>
+            <div class="tooltip-info">
+              <span class="tooltip-content">
+                Personal access token with read:org permission is required.
+              </span>
+            </div>
+        </label>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[PersonalAccessToken].$error.server}" type="password" ng-model="PersonalAccessToken" ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[PersonalAccessToken].$error.server}" ng-show="GOINPUTNAME[PersonalAccessToken].$error.server">{{GOINPUTNAME[PersonalAccessToken].$error.server}}</span>
+    </div>
+
     <div class="form_item_block">
         <label ng-class="{'is-invalid-label': GOINPUTNAME[AllowedOrganizations].$error.server}">GitHub Organizations <small>(Enter comma-separated)</small>:
             <div class="tooltip-info">

--- a/src/test/java/cd/go/authorization/github/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -78,6 +78,20 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "      \"required\": false,\n" +
                 "      \"secure\": false\n" +
                 "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"AuthorizeUsing\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": true,\n" +
+                "      \"secure\": false\n" +
+                "    }\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"PersonalAccessToken\",\n" +
+                "    \"metadata\": {\n" +
+                "      \"required\": false,\n" +
+                "      \"secure\": true\n" +
+                "    }\n" +
                 "  }\n" +
                 "]";
 

--- a/src/test/java/cd/go/authorization/github/executors/GetAuthorizationServerUrlRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetAuthorizationServerUrlRequestExecutorTest.java
@@ -66,8 +66,7 @@ public class GetAuthorizationServerUrlRequestExecutorTest {
 
     @Test
     public void shouldReturnAuthorizationServerUrlForGitHub() throws Exception {
-        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret",
-                AuthenticateWith.GITHUB, null, "example-1");
+        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret", AuthenticateWith.GITHUB, null, "example-1");
 
         when(authConfig.gitHubConfiguration()).thenReturn(gitHubConfiguration);
         when(request.authConfigs()).thenReturn(Collections.singletonList(authConfig));
@@ -76,13 +75,12 @@ public class GetAuthorizationServerUrlRequestExecutorTest {
         final GoPluginApiResponse response = executor.execute();
 
         assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"https://github.com/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email,%20read:org\"}"));
+        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"https://github.com/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email\"}"));
     }
 
     @Test
     public void shouldReturnAuthorizationServerUrlWithTrailingSlash() throws Exception {
-        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret",
-                AuthenticateWith.GITHUB_ENTERPRISE, "http://enterprise.url/", "example-1");
+        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret", AuthenticateWith.GITHUB_ENTERPRISE, "http://enterprise.url/", "example-1");
 
         when(authConfig.gitHubConfiguration()).thenReturn(gitHubConfiguration);
         when(request.authConfigs()).thenReturn(Collections.singletonList(authConfig));
@@ -91,13 +89,12 @@ public class GetAuthorizationServerUrlRequestExecutorTest {
         final GoPluginApiResponse response = executor.execute();
 
         assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"http://enterprise.url/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email,%20read:org\"}"));
+        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"http://enterprise.url/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email\"}"));
     }
 
     @Test
     public void shouldReturnAuthorizationServerUrlForGitHubEnterprise() throws Exception {
-        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret",
-                AuthenticateWith.GITHUB_ENTERPRISE, "http://enterprise.url", "example-1");
+        GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret", AuthenticateWith.GITHUB_ENTERPRISE, "http://enterprise.url", "example-1");
 
         when(authConfig.gitHubConfiguration()).thenReturn(gitHubConfiguration);
         when(request.authConfigs()).thenReturn(Collections.singletonList(authConfig));
@@ -106,6 +103,6 @@ public class GetAuthorizationServerUrlRequestExecutorTest {
         final GoPluginApiResponse response = executor.execute();
 
         assertThat(response.responseCode(), is(200));
-        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"http://enterprise.url/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email,%20read:org\"}"));
+        assertThat(response.responseBody(), startsWith("{\"authorization_server_url\":\"http://enterprise.url/login/oauth/authorize?client_id\\u003dclient-id\\u0026redirect_uri\\u003dcall-back-url\\u0026scope\\u003duser:email\"}"));
     }
 }

--- a/src/test/java/cd/go/authorization/github/models/GitHubConfigurationTest.java
+++ b/src/test/java/cd/go/authorization/github/models/GitHubConfigurationTest.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class GitHubConfigurationTest {
 
@@ -35,7 +36,9 @@ public class GitHubConfigurationTest {
                 "  \"AllowedOrganizations\": \"example-1,example-2\",\n" +
                 "  \"AuthenticateWith\": \"GitHubEnterprise\",\n" +
                 "  \"GitHubEnterpriseUrl\": \"https://enterprise.url\",\n" +
-                "  \"ClientSecret\": \"client-secret\"\n" +
+                "  \"ClientSecret\": \"client-secret\",\n" +
+                "  \"PersonalAccessToken\": \"personal-access-token\",\n" +
+                "  \"AuthorizeUsing\": \"PersonalAccessToken\"\n" +
                 "}");
 
         assertThat(gitHubConfiguration.clientId(), is("client-id"));
@@ -43,6 +46,8 @@ public class GitHubConfigurationTest {
         assertThat(gitHubConfiguration.organizationsAllowed(), contains("example-1", "example-2"));
         assertThat(gitHubConfiguration.gitHubEnterpriseUrl(), is("https://enterprise.url"));
         assertThat(gitHubConfiguration.authenticateWith(), is(AuthenticateWith.GITHUB_ENTERPRISE));
+        assertTrue(gitHubConfiguration.authorizeUsingPersonalAccessToken());
+        assertThat(gitHubConfiguration.personalAccessToken(), is("personal-access-token"));
     }
 
     @Test
@@ -55,7 +60,8 @@ public class GitHubConfigurationTest {
                 "  \"ClientSecret\": \"client-secret\",\n" +
                 "  \"AuthenticateWith\": \"GitHubEnterprise\",\n" +
                 "  \"GitHubEnterpriseUrl\": \"http://enterprise.url\",\n" +
-                "  \"AllowedOrganizations\": \"example-1\"\n" +
+                "  \"AllowedOrganizations\": \"example-1\",\n" +
+                "  \"AuthorizeUsing\": PersonalAccessToken\n" +
                 "}";
 
         JSONAssert.assertEquals(expectedJSON, gitHubConfiguration.toJSON(), true);


### PR DESCRIPTION

- Allow admin to choose authorization using `PersonalAccessToken` or `UserAccessToken`

	- PersonalAccessToken: requires an additional `read:org` permission on `PersonalAccessToken` to authorize user based on role configuration.
	- UserAccessToken: requires an additional `read:org` permission
from user. This allows plugins to access private org and teams of user.