### PR TITLE
Avoid locking up server threads when rate limited by GitHub

### DIFF
--- a/src/main/java/cd/go/authorization/github/GitHubClientBuilder.java
+++ b/src/main/java/cd/go/authorization/github/GitHubClientBuilder.java
@@ -19,6 +19,8 @@ package cd.go.authorization.github;
 import cd.go.authorization.github.models.AuthenticateWith;
 import cd.go.authorization.github.models.GitHubConfiguration;
 import org.kohsuke.github.GitHub;
+import org.kohsuke.github.GitHubBuilder;
+import org.kohsuke.github.RateLimitHandler;
 
 import java.io.IOException;
 
@@ -36,7 +38,7 @@ public class GitHubClientBuilder {
             return GitHub.connectToEnterprise(gitHubConfiguration.gitHubEnterpriseUrl(), accessToken);
         } else {
             LOG.debug("Create GitHub connection to public GitHub with token");
-            return GitHub.connectUsingOAuth(accessToken);
+            return new GitHubBuilder().withOAuthToken(accessToken).withRateLimitHandler(RateLimitHandler.FAIL).build();
         }
     }
 }


### PR DESCRIPTION
This plugin currently creates instances of the GitHub API client with the default rate limit handler, which is the WAIT[1] handler. Its behavior is to sleep until the rate limiting window is reset, as instructed by GitHub, and retry. The result is that gocd server request threads end up blocked in this retry-sleep loop, which eventually exhausts the servlet container's thread pool, and basically brings down the entire server.

This pull-request specifies the alternative handler - FAIL - that will throw an IOException for rate limit failures. This may temporarily inconvenience users but will avoid bringing down the entire server.

[1] https://github.com/kohsuke/github-api/blob/master/src/main/java/org/kohsuke/github/RateLimitHandler.java#L35