### PR TITLE
Use authorisation extension v2.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     testCompile group: 'org.skyscreamer', name: 'jsonassert', version: '1.5.0'
     testCompile group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
     testCompile group: 'com.squareup.okhttp3', name: 'mockwebserver', version: '3.12.0'
+    testCompile group: 'org.jsoup', name: 'jsoup', version: '1.11.3'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ apply from: 'plugin-helpers.gradle'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-project.ext.pluginVersion = '2.2.0'
+project.ext.pluginVersion = '3.0.0'
 project.ext.fullVersion = project.git.distVersion() ? "${project.pluginVersion}-${project.git.distVersion()}" : project.pluginVersion
 
 version = project.fullVersion
@@ -34,7 +34,7 @@ project.ext.pluginDesc = [
         id         : 'cd.go.authorization.github',
         repo       : rootProject.name,
         version    : project.fullVersion,
-        goCdVersion: '17.5.0',
+        goCdVersion: '19.2.0',
         name       : 'GitHub OAuth authorization plugin',
         description: 'GitHub OAuth authorization plugin for GoCD',
         vendorName : 'GoCD Contributors',

--- a/plugin-helpers.gradle
+++ b/plugin-helpers.gradle
@@ -22,9 +22,9 @@ static String gitRevision() {
 }
 
 static String distVersion() {
-    def process = "git rev-list --count HEAD".execute()
+    def process = "git rev-list HEAD".execute()
     process.waitFor()
-    return process.text.stripIndent().trim()
+    return process.text.stripIndent().trim().split("\n").size()
 }
 
 static def getLastTag(boolean isExperimental) {

--- a/src/main/java/cd/go/authorization/github/Constants.java
+++ b/src/main/java/cd/go/authorization/github/Constants.java
@@ -25,7 +25,7 @@ public interface Constants {
     String EXTENSION_TYPE = "authorization";
 
     // The extension point API version that this plugin understands
-    String API_VERSION = "1.0";
+    String API_VERSION = "2.0";
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));

--- a/src/main/java/cd/go/authorization/github/GitHubAuthenticator.java
+++ b/src/main/java/cd/go/authorization/github/GitHubAuthenticator.java
@@ -45,7 +45,7 @@ public class GitHubAuthenticator {
         final List<String> allowedOrganizations = authConfig.gitHubConfiguration().organizationsAllowed();
         final LoggedInUserInfo loggedInUserInfo = new LoggedInUserInfo(gitHub);
 
-        if (allowedOrganizations.isEmpty() || membershipChecker.isAMemberOfAtLeastOneOrganization(loggedInUserInfo, authConfig, allowedOrganizations)) {
+        if (allowedOrganizations.isEmpty() || membershipChecker.isAMemberOfAtLeastOneOrganization(loggedInUserInfo.getGitHubUser(), authConfig, allowedOrganizations)) {
             LOG.info(format("[Authenticate] User `{0}` authenticated successfully.", loggedInUserInfo.getUser().username()));
             return loggedInUserInfo;
         }

--- a/src/main/java/cd/go/authorization/github/GitHubAuthorizer.java
+++ b/src/main/java/cd/go/authorization/github/GitHubAuthorizer.java
@@ -17,9 +17,8 @@
 package cd.go.authorization.github;
 
 import cd.go.authorization.github.models.AuthConfig;
-import cd.go.authorization.github.models.LoggedInUserInfo;
 import cd.go.authorization.github.models.Role;
-import cd.go.authorization.github.models.User;
+import org.kohsuke.github.GHUser;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -39,37 +38,36 @@ public class GitHubAuthorizer {
         this.membershipChecker = membershipChecker;
     }
 
-    public List<String> authorize(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, List<Role> roles) throws IOException {
-        final User user = loggedInUserInfo.getUser();
+    public List<String> authorize(GHUser user, AuthConfig authConfig, List<Role> roles) throws IOException {
         final List<String> assignedRoles = new ArrayList<>();
 
         if (roles.isEmpty()) {
             return assignedRoles;
         }
 
-        LOG.debug(format("[Authorize] Authorizing user {0}", user.username()));
+        LOG.debug(format("[Authorize] Authorizing user {0}", user.getLogin()));
 
         for (Role role : roles) {
             final List<String> allowedUsers = role.roleConfiguration().users();
-            if (!allowedUsers.isEmpty() && allowedUsers.contains(user.username().toLowerCase())) {
-                LOG.info(format("[Authorize] Assigning role `{0}` to user `{1}`. As user belongs to allowed users list.", role.name(), user.username()));
+            if (!allowedUsers.isEmpty() && allowedUsers.contains(user.getLogin().toLowerCase())) {
+                LOG.info(format("[Authorize] Assigning role `{0}` to user `{1}`. As user belongs to allowed users list.", role.name(), user.getLogin()));
                 assignedRoles.add(role.name());
                 continue;
             }
 
-            if (membershipChecker.isAMemberOfAtLeastOneOrganization(loggedInUserInfo, authConfig, role.roleConfiguration().organizations())) {
-                LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one organization.", role.name(), user.username()));
+            if (membershipChecker.isAMemberOfAtLeastOneOrganization(user, authConfig, role.roleConfiguration().organizations())) {
+                LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one organization.", role.name(), user.getLogin()));
                 assignedRoles.add(role.name());
                 continue;
             }
 
-            if (membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(loggedInUserInfo, authConfig, role.roleConfiguration().teams())) {
-                LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one team of the organization.", role.name(), user.username()));
+            if (membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(user, authConfig, role.roleConfiguration().teams())) {
+                LOG.debug(format("[Authorize] Assigning role `{0}` to user `{1}`. As user is a member of at least one team of the organization.", role.name(), user.getLogin()));
                 assignedRoles.add(role.name());
             }
         }
 
-        LOG.debug(format("[Authorize] User `{0}` is authorized with `{1}` role(s).", user.username(), assignedRoles));
+        LOG.debug(format("[Authorize] User `{0}` is authorized with `{1}` role(s).", user.getLogin(), assignedRoles));
 
         return assignedRoles;
     }

--- a/src/main/java/cd/go/authorization/github/GitHubPlugin.java
+++ b/src/main/java/cd/go/authorization/github/GitHubPlugin.java
@@ -42,7 +42,7 @@ public class GitHubPlugin implements GoPlugin {
     }
 
     @Override
-    public GoPluginApiResponse handle(GoPluginApiRequest request) throws UnhandledRequestTypeException {
+    public GoPluginApiResponse handle(GoPluginApiRequest request) {
         try {
             switch (RequestFromServer.fromString(request.requestName())) {
                 case REQUEST_GET_PLUGIN_ICON:
@@ -67,10 +67,14 @@ public class GitHubPlugin implements GoPlugin {
                     return GetAuthorizationServerUrlRequest.from(request).execute();
                 case REQUEST_ACCESS_TOKEN:
                     return FetchAccessTokenRequest.from(request).execute();
+                case REQUEST_IS_VALID_USER:
+                    return ValidateUserRequest.from(request).execute();
                 case REQUEST_AUTHENTICATE_USER:
                     return UserAuthenticationRequest.from(request).execute();
                 case REQUEST_SEARCH_USERS:
-                    return new SearchUsersRequestExecutor(request).execute();
+                    return SearchUsersRequest.from(request).execute();
+                case REQUEST_GET_USER_ROLES:
+                    return GetRolesRequest.from(request).execute();
                 default:
                     throw new UnhandledRequestTypeException(request.requestName());
             }

--- a/src/main/java/cd/go/authorization/github/MembershipChecker.java
+++ b/src/main/java/cd/go/authorization/github/MembershipChecker.java
@@ -17,42 +17,46 @@
 package cd.go.authorization.github;
 
 import cd.go.authorization.github.models.AuthConfig;
-import cd.go.authorization.github.models.LoggedInUserInfo;
 import org.kohsuke.github.GHOrganization;
 import org.kohsuke.github.GHTeam;
+import org.kohsuke.github.GHUser;
 import org.kohsuke.github.GitHub;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static cd.go.authorization.github.GitHubPlugin.LOG;
-import static cd.go.authorization.github.utils.Util.toLowerCase;
 import static java.text.MessageFormat.format;
 
 public class MembershipChecker {
+    private GitHubClientBuilder clientBuilder;
 
-    public boolean isAMemberOfAtLeastOneOrganization(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, List<String> organizationsAllowed) throws IOException {
+    public MembershipChecker() {
+        this(new GitHubClientBuilder());
+    }
+
+    MembershipChecker(GitHubClientBuilder clientBuilder) {
+        this.clientBuilder = clientBuilder;
+    }
+
+
+    public boolean isAMemberOfAtLeastOneOrganization(GHUser ghUser, AuthConfig authConfig, List<String> organizationsAllowed) throws IOException {
         if (organizationsAllowed.isEmpty()) {
             LOG.debug("[MembershipChecker] No organizations provided.");
             return false;
         }
 
-        if (authConfig.gitHubConfiguration().authorizeUsingPersonalAccessToken()) {
-            return checkMembershipUsingPersonalAccessToken(loggedInUserInfo, authConfig, organizationsAllowed);
-        }
-
-        return checkMembershipUsingUsersAccessToken(loggedInUserInfo, organizationsAllowed);
+        return checkMembershipUsingPersonalAccessToken(ghUser, authConfig, organizationsAllowed);
     }
 
-    private boolean checkMembershipUsingPersonalAccessToken(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, List<String> organizationsAllowed) throws IOException {
-        final GitHub gitHubForPersonalAccessToken = authConfig.gitHubConfiguration().gitHubClient();
+    private boolean checkMembershipUsingPersonalAccessToken(GHUser ghUser, AuthConfig authConfig, List<String> organizationsAllowed) throws IOException {
+        final GitHub gitHubForPersonalAccessToken = clientBuilder.build(null, authConfig.gitHubConfiguration());
 
         for (String organizationName : organizationsAllowed) {
             final GHOrganization organization = gitHubForPersonalAccessToken.getOrganization(organizationName);
-            if (organization != null && organization.hasMember(loggedInUserInfo.getGitHubUser())) {
-                LOG.info(format("[MembershipChecker] User `{0}` is a member of `{1}` organization.", loggedInUserInfo.getUser().username(), organizationName));
+            if (organization != null && organization.hasMember(ghUser)) {
+                LOG.info(format("[MembershipChecker] User `{0}` is a member of `{1}` organization.", ghUser.getLogin(), organizationName));
                 return true;
             }
         }
@@ -60,34 +64,17 @@ public class MembershipChecker {
         return false;
     }
 
-    private boolean checkMembershipUsingUsersAccessToken(LoggedInUserInfo loggedInUserInfo, List<String> organizationsAllowed) throws IOException {
-        final Map<String, GHOrganization> myGitHubOrganizations = loggedInUserInfo.getGitHub().getMyOrganizations();
-
-        for (String organizationName : myGitHubOrganizations.keySet()) {
-            if (organizationsAllowed.contains(toLowerCase(organizationName))) {
-                LOG.info(format("[MembershipChecker] User `{0}` is a member of `{1}` organization.", loggedInUserInfo.getUser().username(), organizationName));
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    public boolean isAMemberOfAtLeastOneTeamOfOrganization(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, Map<String, List<String>> organizationAndTeamsAllowed) throws IOException {
+    public boolean isAMemberOfAtLeastOneTeamOfOrganization(GHUser ghUser, AuthConfig authConfig, Map<String, List<String>> organizationAndTeamsAllowed) throws IOException {
         if (organizationAndTeamsAllowed.isEmpty()) {
             LOG.debug("[MembershipChecker] No teams provided.");
             return false;
         }
 
-        if (authConfig.gitHubConfiguration().authorizeUsingPersonalAccessToken()) {
-            return checkTeamMembershipUsingPersonalAccessToken(loggedInUserInfo, authConfig, organizationAndTeamsAllowed);
-        }
-
-        return checkTeamMembershipUsingUserAccessToken(loggedInUserInfo, organizationAndTeamsAllowed);
+        return checkTeamMembershipUsingPersonalAccessToken(ghUser, authConfig, organizationAndTeamsAllowed);
     }
 
-    private boolean checkTeamMembershipUsingPersonalAccessToken(LoggedInUserInfo loggedInUserInfo, AuthConfig authConfig, Map<String, List<String>> organizationAndTeamsAllowed) throws IOException {
-        final GitHub gitHubForPersonalAccessToken = authConfig.gitHubConfiguration().gitHubClient();
+    private boolean checkTeamMembershipUsingPersonalAccessToken(GHUser ghUser, AuthConfig authConfig, Map<String, List<String>> organizationAndTeamsAllowed) throws IOException {
+        final GitHub gitHubForPersonalAccessToken = clientBuilder.build(null, authConfig.gitHubConfiguration());
 
         for (String organizationName : organizationAndTeamsAllowed.keySet()) {
             final GHOrganization organization = gitHubForPersonalAccessToken.getOrganization(organizationName);
@@ -97,32 +84,10 @@ public class MembershipChecker {
                 final Map<String, GHTeam> teamsFromGitHub = organization.getTeams();
 
                 for (GHTeam team : teamsFromGitHub.values()) {
-                    if (allowedTeamsFromRole.contains(team.getName().toLowerCase()) && team.hasMember(loggedInUserInfo.getGitHubUser())) {
-                        LOG.info(format("[MembershipChecker] User `{0}` is a member of `{1}` team.", loggedInUserInfo.getUser().username(), team.getName()));
+                    if (allowedTeamsFromRole.contains(team.getName().toLowerCase()) && team.hasMember(ghUser)) {
+                        LOG.info(format("[MembershipChecker] User `{0}` is a member of `{1}` team.", ghUser.getLogin(), team.getName()));
                         return true;
                     }
-                }
-            }
-        }
-
-        return false;
-    }
-
-    private boolean checkTeamMembershipUsingUserAccessToken(LoggedInUserInfo loggedInUserInfo, Map<String, List<String>> organizationAndTeamsAllowed) throws IOException {
-        final Map<String, Set<GHTeam>> myGitHubOrganizationsAndTeams = loggedInUserInfo.getGitHub().getMyTeams();
-
-        for (String organizationName : myGitHubOrganizationsAndTeams.keySet()) {
-            final List<String> teamsAllowed = organizationAndTeamsAllowed.get(toLowerCase(organizationName));
-
-            if (teamsAllowed == null || teamsAllowed.isEmpty()) {
-                LOG.debug(format("[MembershipChecker] No teams specified for organization `{0}`.", organizationName));
-                continue;
-            }
-
-            for (GHTeam myGitHubTeam : myGitHubOrganizationsAndTeams.get(organizationName)) {
-                if (teamsAllowed.contains(toLowerCase(myGitHubTeam.getName()))) {
-                    LOG.debug(format("[MembershipChecker] User is a member of `{0}:{1}` team.", organizationName, myGitHubTeam.getName()));
-                    return true;
                 }
             }
         }

--- a/src/main/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutor.java
@@ -34,7 +34,7 @@ public class AuthConfigValidateRequestExecutor implements RequestExecutor {
         this.request = request;
     }
 
-    public GoPluginApiResponse execute() throws Exception {
+    public GoPluginApiResponse execute() {
         final GitHubConfiguration gitHubConfiguration = request.githubConfiguration();
         final ValidationResult validationResult = new MetadataValidator().validate(gitHubConfiguration);
 
@@ -42,7 +42,7 @@ public class AuthConfigValidateRequestExecutor implements RequestExecutor {
             validationResult.addError("GitHubEnterpriseUrl", "GitHubEnterpriseUrl must not be blank.");
         }
 
-        if (gitHubConfiguration.authorizeUsingPersonalAccessToken() && Util.isBlank(gitHubConfiguration.personalAccessToken())) {
+        if (Util.isBlank(gitHubConfiguration.personalAccessToken())) {
             validationResult.addError("PersonalAccessToken", "PersonalAccessToken must not be blank.");
         }
 

--- a/src/main/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutor.java
@@ -26,7 +26,7 @@ import static cd.go.authorization.github.utils.Util.GSON;
 public class GetAuthConfigViewRequestExecutor implements RequestExecutor {
 
     @Override
-    public GoPluginApiResponse execute() throws Exception {
+    public GoPluginApiResponse execute() {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("template", Util.readResource("/auth-config.template.html"));
         return DefaultGoPluginApiResponse.success(GSON.toJson(jsonObject));

--- a/src/main/java/cd/go/authorization/github/executors/GetCapabilitiesRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/GetCapabilitiesRequestExecutor.java
@@ -31,6 +31,6 @@ public class GetCapabilitiesRequestExecutor {
     }
 
     Capabilities getCapabilities() {
-        return new Capabilities(SupportedAuthType.Web, true, true);
+        return new Capabilities(SupportedAuthType.Web, true, true, true);
     }
 }

--- a/src/main/java/cd/go/authorization/github/executors/GetRolesExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/GetRolesExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import cd.go.authorization.github.GitHubAuthorizer;
+import cd.go.authorization.github.GitHubClientBuilder;
+import cd.go.authorization.github.requests.GetRolesRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+
+import java.io.IOException;
+import java.util.List;
+
+import static cd.go.authorization.github.GitHubPlugin.LOG;
+import static cd.go.authorization.github.utils.Util.GSON;
+import static java.lang.String.format;
+
+public class GetRolesExecutor implements RequestExecutor {
+    private final GetRolesRequest request;
+    private GitHubClientBuilder clientBuilder;
+    private final GitHubAuthorizer gitHubAuthorizer;
+
+    public GetRolesExecutor(GetRolesRequest request) {
+        this(request, new GitHubAuthorizer(), new GitHubClientBuilder());
+    }
+
+    GetRolesExecutor(GetRolesRequest request, GitHubAuthorizer gitHubAuthorizer, GitHubClientBuilder clientBuilder) {
+        this.request = request;
+        this.clientBuilder = clientBuilder;
+        this.gitHubAuthorizer = gitHubAuthorizer;
+    }
+
+    @Override
+    public GoPluginApiResponse execute() throws IOException {
+        if (request.getRoles().isEmpty()) {
+            LOG.debug("[Get User Roles] Server sent empty roles config. Nothing to do!.");
+            return DefaultGoPluginApiResponse.success("[]");
+        }
+
+        GitHub gitHub = clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration());
+        GHUser user = gitHub.getUser(request.getUsername());
+
+        if (user == null) {
+            LOG.error(format("[Get User Roles] User %s does not exist in GitHub.", request.getUsername()));
+            return DefaultGoPluginApiResponse.error("");
+        }
+
+        List<String> roles = gitHubAuthorizer.authorize(user, request.getAuthConfig(), request.getRoles());
+
+        LOG.debug(format("[Get User Roles] User %s has %s roles.", request.getUsername(), roles));
+        return DefaultGoPluginApiResponse.success(GSON.toJson(roles));
+    }
+}
+

--- a/src/main/java/cd/go/authorization/github/executors/RequestFromServer.java
+++ b/src/main/java/cd/go/authorization/github/executors/RequestFromServer.java
@@ -32,6 +32,9 @@ public enum RequestFromServer {
     REQUEST_ROLE_CONFIG_VIEW(String.join(".", Constants.REQUEST_PREFIX, Constants._ROLE_CONFIG_METADATA, "get-view")),
     REQUEST_VALIDATE_ROLE_CONFIG(String.join(".", Constants.REQUEST_PREFIX, Constants._ROLE_CONFIG_METADATA, "validate")),
 
+    REQUEST_GET_USER_ROLES(String.join(".", Constants.REQUEST_PREFIX, "get-user-roles")),
+    REQUEST_IS_VALID_USER(String.join(".", Constants.REQUEST_PREFIX, "is-valid-user")),
+
     REQUEST_AUTHENTICATE_USER(Constants.REQUEST_PREFIX + ".authenticate-user"),
     REQUEST_SEARCH_USERS(Constants.REQUEST_PREFIX + ".search-users"),
 

--- a/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
@@ -18,7 +18,6 @@ package cd.go.authorization.github.executors;
 
 import cd.go.authorization.github.GitHubAuthenticator;
 import cd.go.authorization.github.GitHubAuthorizer;
-import cd.go.authorization.github.GitHubClientBuilder;
 import cd.go.authorization.github.exceptions.NoAuthorizationConfigurationException;
 import cd.go.authorization.github.models.AuthConfig;
 import cd.go.authorization.github.models.LoggedInUserInfo;
@@ -30,21 +29,18 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static cd.go.authorization.github.utils.Util.GSON;
-import static com.thoughtworks.go.plugin.api.response.DefaultGoApiResponse.SUCCESS_RESPONSE_CODE;
 
 public class UserAuthenticationRequestExecutor implements RequestExecutor {
     private final UserAuthenticationRequest request;
-    private final GitHubClientBuilder providerManager;
     private final GitHubAuthenticator gitHubAuthenticator;
     private final GitHubAuthorizer gitHubAuthorizer;
 
     public UserAuthenticationRequestExecutor(UserAuthenticationRequest request) {
-        this(request, new GitHubClientBuilder(), new GitHubAuthenticator(), new GitHubAuthorizer());
+        this(request, new GitHubAuthenticator(), new GitHubAuthorizer());
     }
 
-    UserAuthenticationRequestExecutor(UserAuthenticationRequest request, GitHubClientBuilder providerManager, GitHubAuthenticator gitHubAuthenticator, GitHubAuthorizer gitHubAuthorizer) {
+    UserAuthenticationRequestExecutor(UserAuthenticationRequest request, GitHubAuthenticator gitHubAuthenticator, GitHubAuthorizer gitHubAuthorizer) {
         this.request = request;
-        this.providerManager = providerManager;
         this.gitHubAuthenticator = gitHubAuthenticator;
         this.gitHubAuthorizer = gitHubAuthorizer;
     }
@@ -64,7 +60,6 @@ public class UserAuthenticationRequestExecutor implements RequestExecutor {
             userMap.put("roles", gitHubAuthorizer.authorize(loggedInUserInfo.getGitHubUser(), authConfig, request.roles()));
         }
 
-        DefaultGoPluginApiResponse response = new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, GSON.toJson(userMap));
-        return response;
+        return DefaultGoPluginApiResponse.success(GSON.toJson(userMap));
     }
 }

--- a/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutor.java
@@ -61,7 +61,7 @@ public class UserAuthenticationRequestExecutor implements RequestExecutor {
         Map<String, Object> userMap = new HashMap<>();
         if (loggedInUserInfo != null) {
             userMap.put("user", loggedInUserInfo.getUser());
-            userMap.put("roles", gitHubAuthorizer.authorize(loggedInUserInfo, authConfig, request.roles()));
+            userMap.put("roles", gitHubAuthorizer.authorize(loggedInUserInfo.getGitHubUser(), authConfig, request.roles()));
         }
 
         DefaultGoPluginApiResponse response = new DefaultGoPluginApiResponse(SUCCESS_RESPONSE_CODE, GSON.toJson(userMap));

--- a/src/main/java/cd/go/authorization/github/executors/ValidateUserRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/ValidateUserRequestExecutor.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import cd.go.authorization.github.GitHubClientBuilder;
+import cd.go.authorization.github.requests.ValidateUserRequest;
+import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+
+import static cd.go.authorization.github.GitHubPlugin.LOG;
+import static java.lang.String.format;
+
+public class ValidateUserRequestExecutor implements RequestExecutor {
+    private ValidateUserRequest request;
+    private final GitHubClientBuilder clientBuilder;
+
+    public ValidateUserRequestExecutor(ValidateUserRequest request) {
+        this(request, new GitHubClientBuilder());
+    }
+
+    ValidateUserRequestExecutor(ValidateUserRequest request, GitHubClientBuilder clientBuilder) {
+        this.request = request;
+        this.clientBuilder = clientBuilder;
+    }
+
+    @Override
+    public GoPluginApiResponse execute() throws Exception {
+        GitHub gitHub = clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration());
+        GHUser user = gitHub.getUser(request.getUsername());
+        if (user == null) {
+            LOG.error(format("[Is Valid User] User %s does not exist in GitHub.", request.getUsername()));
+            return DefaultGoPluginApiResponse.error(String.format("User '%s' does not exist in GitHub.", request.getUsername()));
+        } else {
+            LOG.info(format("[Is Valid User] %s is valid user.", request.getUsername()));
+            return DefaultGoPluginApiResponse.success("");
+        }
+    }
+}

--- a/src/main/java/cd/go/authorization/github/models/Capabilities.java
+++ b/src/main/java/cd/go/authorization/github/models/Capabilities.java
@@ -31,11 +31,15 @@ public class Capabilities {
     @Expose
     @SerializedName("can_authorize")
     private final boolean canAuthorize;
+    @Expose
+    @SerializedName("can_get_user_roles")
+    private final boolean canGetUserRoles;
 
-    public Capabilities(SupportedAuthType supportedAuthType, boolean canSearch, boolean canAuthorize) {
+    public Capabilities(SupportedAuthType supportedAuthType, boolean canSearch, boolean canAuthorize, boolean canGetUserRoles) {
         this.supportedAuthType = supportedAuthType;
         this.canSearch = canSearch;
         this.canAuthorize = canAuthorize;
+        this.canGetUserRoles = canGetUserRoles;
     }
 
     public String toJSON() {

--- a/src/main/java/cd/go/authorization/github/models/GitHubConfiguration.java
+++ b/src/main/java/cd/go/authorization/github/models/GitHubConfiguration.java
@@ -16,23 +16,21 @@
 
 package cd.go.authorization.github.models;
 
-import cd.go.authorization.github.GitHubClientBuilder;
 import cd.go.authorization.github.annotation.ProfileField;
 import cd.go.authorization.github.annotation.Validatable;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
-import org.kohsuke.github.GitHub;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static cd.go.authorization.github.utils.Util.*;
 
 public class GitHubConfiguration implements Validatable {
+    private static final String GITHUB_URL = "https://github.com";
 
-    public static final String GITHUB_URL = "https://github.com";
     @Expose
     @SerializedName("ClientId")
     @ProfileField(key = "ClientId", required = true, secure = true)
@@ -59,13 +57,8 @@ public class GitHubConfiguration implements Validatable {
     private String allowedOrganizations;
 
     @Expose
-    @SerializedName("AuthorizeUsing")
-    @ProfileField(key = "AuthorizeUsing", required = true, secure = false)
-    private String authorizeUsing = "PersonalAccessToken";
-
-    @Expose
     @SerializedName("PersonalAccessToken")
-    @ProfileField(key = "PersonalAccessToken", required = false, secure = true)
+    @ProfileField(key = "PersonalAccessToken", required = true, secure = true)
     private String personalAccessToken;
 
 
@@ -109,7 +102,7 @@ public class GitHubConfiguration implements Validatable {
     }
 
     public String scope() {
-        return authorizeUsingPersonalAccessToken() ? "user:email" : "user:email, read:org";
+        return "user:email";
     }
 
     public static GitHubConfiguration fromJSON(String json) {
@@ -125,10 +118,6 @@ public class GitHubConfiguration implements Validatable {
         }.getType());
     }
 
-    public boolean authorizeUsingPersonalAccessToken() {
-        return "PersonalAccessToken".equalsIgnoreCase(authorizeUsing);
-    }
-
     public String personalAccessToken() {
         return personalAccessToken;
     }
@@ -137,28 +126,18 @@ public class GitHubConfiguration implements Validatable {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-
         GitHubConfiguration that = (GitHubConfiguration) o;
-
-        if (clientId != null ? !clientId.equals(that.clientId) : that.clientId != null) return false;
-        if (clientSecret != null ? !clientSecret.equals(that.clientSecret) : that.clientSecret != null) return false;
-        if (authenticateWith != that.authenticateWith) return false;
-        if (gitHubEnterpriseUrl != null ? !gitHubEnterpriseUrl.equals(that.gitHubEnterpriseUrl) : that.gitHubEnterpriseUrl != null)
-            return false;
-        return allowedOrganizations != null ? allowedOrganizations.equals(that.allowedOrganizations) : that.allowedOrganizations == null;
+        return Objects.equals(clientId, that.clientId) &&
+                Objects.equals(clientSecret, that.clientSecret) &&
+                authenticateWith == that.authenticateWith &&
+                Objects.equals(gitHubEnterpriseUrl, that.gitHubEnterpriseUrl) &&
+                Objects.equals(allowedOrganizations, that.allowedOrganizations) &&
+                Objects.equals(personalAccessToken, that.personalAccessToken);
     }
 
     @Override
     public int hashCode() {
-        int result = clientId != null ? clientId.hashCode() : 0;
-        result = 31 * result + (clientSecret != null ? clientSecret.hashCode() : 0);
-        result = 31 * result + (authenticateWith != null ? authenticateWith.hashCode() : 0);
-        result = 31 * result + (gitHubEnterpriseUrl != null ? gitHubEnterpriseUrl.hashCode() : 0);
-        result = 31 * result + (allowedOrganizations != null ? allowedOrganizations.hashCode() : 0);
-        return result;
-    }
-
-    public GitHub gitHubClient() throws IOException {
-        return new GitHubClientBuilder().build(personalAccessToken, this);
+        return Objects.hash(clientId, clientSecret, authenticateWith, gitHubEnterpriseUrl, allowedOrganizations, personalAccessToken);
     }
 }
+

--- a/src/main/java/cd/go/authorization/github/requests/AuthConfigValidateRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/AuthConfigValidateRequest.java
@@ -17,6 +17,7 @@
 package cd.go.authorization.github.requests;
 
 import cd.go.authorization.github.executors.AuthConfigValidateRequestExecutor;
+import cd.go.authorization.github.executors.RequestExecutor;
 import cd.go.authorization.github.models.GitHubConfiguration;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 
@@ -36,7 +37,7 @@ public class AuthConfigValidateRequest extends Request {
     }
 
     @Override
-    public AuthConfigValidateRequestExecutor executor() {
+    public RequestExecutor executor() {
         return new AuthConfigValidateRequestExecutor(this);
     }
 }

--- a/src/main/java/cd/go/authorization/github/requests/GetAuthorizationServerUrlRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/GetAuthorizationServerUrlRequest.java
@@ -17,6 +17,7 @@
 package cd.go.authorization.github.requests;
 
 import cd.go.authorization.github.executors.GetAuthorizationServerUrlRequestExecutor;
+import cd.go.authorization.github.executors.RequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
@@ -46,7 +47,7 @@ public class GetAuthorizationServerUrlRequest extends Request {
     }
 
     @Override
-    public GetAuthorizationServerUrlRequestExecutor executor() {
+    public RequestExecutor executor() {
         return new GetAuthorizationServerUrlRequestExecutor(this);
     }
 }

--- a/src/main/java/cd/go/authorization/github/requests/GetRolesRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/GetRolesRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,47 @@
 
 package cd.go.authorization.github.requests;
 
-import cd.go.authorization.github.executors.FetchAccessTokenRequestExecutor;
+import cd.go.authorization.github.executors.GetRolesExecutor;
 import cd.go.authorization.github.executors.RequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
+import cd.go.authorization.github.models.Role;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 
 import java.util.List;
 
-public class FetchAccessTokenRequest extends Request {
+public class GetRolesRequest extends Request {
     @Expose
-    @SerializedName("auth_configs")
-    private List<AuthConfig> authConfigs;
+    @SerializedName("auth_config")
+    private AuthConfig authConfig;
 
-    public static FetchAccessTokenRequest from(GoPluginApiRequest apiRequest) {
-        return Request.from(apiRequest, FetchAccessTokenRequest.class);
-    }
+    @Expose
+    @SerializedName("role_configs")
+    private List<Role> roles;
 
-    public List<AuthConfig> authConfigs() {
-        return authConfigs;
+    @Expose
+    @SerializedName("username")
+    private String username;
+
+    public static Request from(GoPluginApiRequest request) {
+        return Request.from(request, GetRolesRequest.class);
     }
 
     @Override
     public RequestExecutor executor() {
-        return new FetchAccessTokenRequestExecutor(this);
+        return new GetRolesExecutor(this);
+    }
+
+    public AuthConfig getAuthConfig() {
+        return authConfig;
+    }
+
+    public List<Role> getRoles() {
+        return roles;
+    }
+
+    public String getUsername() {
+        return username;
     }
 }

--- a/src/main/java/cd/go/authorization/github/requests/SearchUsersRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/SearchUsersRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,8 +16,7 @@
 
 package cd.go.authorization.github.requests;
 
-import cd.go.authorization.github.executors.FetchAccessTokenRequestExecutor;
-import cd.go.authorization.github.executors.RequestExecutor;
+import cd.go.authorization.github.executors.SearchUsersRequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
@@ -25,21 +24,29 @@ import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 
 import java.util.List;
 
-public class FetchAccessTokenRequest extends Request {
+public class SearchUsersRequest extends Request {
     @Expose
     @SerializedName("auth_configs")
     private List<AuthConfig> authConfigs;
 
-    public static FetchAccessTokenRequest from(GoPluginApiRequest apiRequest) {
-        return Request.from(apiRequest, FetchAccessTokenRequest.class);
-    }
+    @Expose
+    @SerializedName("search_term")
+    private String searchTerm;
 
-    public List<AuthConfig> authConfigs() {
-        return authConfigs;
+    public static SearchUsersRequest from(GoPluginApiRequest request) {
+        return Request.from(request, SearchUsersRequest.class);
     }
 
     @Override
-    public RequestExecutor executor() {
-        return new FetchAccessTokenRequestExecutor(this);
+    public SearchUsersRequestExecutor executor() {
+        return new SearchUsersRequestExecutor(this);
+    }
+
+    public List<AuthConfig> getAuthConfigs() {
+        return authConfigs;
+    }
+
+    public String getSearchTerm() {
+        return searchTerm;
     }
 }

--- a/src/main/java/cd/go/authorization/github/requests/ValidateUserRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/ValidateUserRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 ThoughtWorks, Inc.
+ * Copyright 2019 ThoughtWorks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,30 +16,36 @@
 
 package cd.go.authorization.github.requests;
 
-import cd.go.authorization.github.executors.FetchAccessTokenRequestExecutor;
 import cd.go.authorization.github.executors.RequestExecutor;
+import cd.go.authorization.github.executors.ValidateUserRequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 
-import java.util.List;
-
-public class FetchAccessTokenRequest extends Request {
+public class ValidateUserRequest extends Request {
     @Expose
-    @SerializedName("auth_configs")
-    private List<AuthConfig> authConfigs;
+    @SerializedName("auth_config")
+    private AuthConfig authConfig;
 
-    public static FetchAccessTokenRequest from(GoPluginApiRequest apiRequest) {
-        return Request.from(apiRequest, FetchAccessTokenRequest.class);
-    }
+    @Expose
+    @SerializedName("username")
+    private String username;
 
-    public List<AuthConfig> authConfigs() {
-        return authConfigs;
+    public static Request from(GoPluginApiRequest request) {
+        return Request.from(request, ValidateUserRequest.class);
     }
 
     @Override
     public RequestExecutor executor() {
-        return new FetchAccessTokenRequestExecutor(this);
+        return new ValidateUserRequestExecutor(this);
+    }
+
+    public AuthConfig getAuthConfig() {
+        return authConfig;
+    }
+
+    public String getUsername() {
+        return username;
     }
 }

--- a/src/main/resources/auth-config.template.html
+++ b/src/main/resources/auth-config.template.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2017 ThoughtWorks, Inc.
+  ~ Copyright 2019 ThoughtWorks, Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@
     </style>
 
 
-    <div  class="form_item_block row" style="padding-top: 10px">
+    <div class="form_item_block row" style="padding-top: 10px">
         <div class="columns small-3 medium-2 larger-2">
             <label>Authenticate with</label>
         </div>
@@ -102,79 +102,81 @@
 
     <div ng-show="AuthenticateWith == 'GitHubEnterprise'">
         <div class="form_item_block">
-            <label ng-class="{'is-invalid-label': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}">GitHub Enterprise Url:<span class='asterix'>*</span>
+            <label ng-class="{'is-invalid-label': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}">GitHub Enterprise
+                Url:<span class='asterix'>*</span>
                 <div class="tooltip-info">
               <span class="tooltip-content">
                 GitHub enterprise url
               </span>
                 </div>
             </label>
-            <input ng-class="{'is-invalid-input': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}" type="text" ng-model="GitHubEnterpriseUrl" ng-required="true"/>
-            <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}" ng-show="GOINPUTNAME[GitHubEnterpriseUrl].$error.server">{{GOINPUTNAME[GitHubEnterpriseUrl].$error.server}}</span>
+            <input ng-class="{'is-invalid-input': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}" type="text"
+                   ng-model="GitHubEnterpriseUrl" ng-required="true"/>
+            <span class="form_error form-error"
+                  ng-class="{'is-visible': GOINPUTNAME[GitHubEnterpriseUrl].$error.server}"
+                  ng-show="GOINPUTNAME[GitHubEnterpriseUrl].$error.server">{{GOINPUTNAME[GitHubEnterpriseUrl].$error.server}}</span>
         </div>
     </div>
 
     <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[ClientId].$error.server}">OAuth Client ID:<span class='asterix'>*</span>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ClientId].$error.server}">OAuth Client ID:<span
+                class='asterix'>*</span>
             <div class="tooltip-info">
               <span class="tooltip-content">
                 Public identifier for the client that is required for all OAuth flows.
               </span>
             </div>
         </label>
-        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientId].$error.server}" type="password" ng-model="ClientId" ng-required="true"/>
-        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientId].$error.server}" ng-show="GOINPUTNAME[ClientId].$error.server">{{GOINPUTNAME[ClientId].$error.server}}</span>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientId].$error.server}" type="password" ng-model="ClientId"
+               ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientId].$error.server}"
+              ng-show="GOINPUTNAME[ClientId].$error.server">{{GOINPUTNAME[ClientId].$error.server}}</span>
     </div>
 
     <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[ClientSecret].$error.server}">OAuth Client Secret:<span class='asterix'>*</span>
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[ClientSecret].$error.server}">OAuth Client Secret:<span
+                class='asterix'>*</span>
             <div class="tooltip-info">
               <span class="tooltip-content">
                 Secret used by the client to exchange an authorization code for a token. This must be kept confidential! Do not include it in apps which cannot keep it secret, such as those running on a client.
               </span>
             </div>
         </label>
-        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientSecret].$error.server}" type="password" ng-model="ClientSecret" ng-required="true"/>
-        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientSecret].$error.server}" ng-show="GOINPUTNAME[ClientSecret].$error.server">{{GOINPUTNAME[ClientSecret].$error.server}}</span>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[ClientSecret].$error.server}" type="password"
+               ng-model="ClientSecret" ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[ClientSecret].$error.server}"
+              ng-show="GOINPUTNAME[ClientSecret].$error.server">{{GOINPUTNAME[ClientSecret].$error.server}}</span>
     </div>
 
-    <div class="form_item_block row" style="padding-top: 10px" ng-init="AuthorizeUsing = (AuthorizeUsing || 'PersonalAccessToken')">
-        <div class="columns small-3 medium-2 larger-2">
-            <label ng-class="{'is-invalid-label': GOINPUTNAME[AuthorizeUsing].$error.server}">Authorize user using</label>
-        </div>
-        <div class="columns small-9 medium-10 larger-10">
-            <input value="PersonalAccessToken" type="radio" ng-model="AuthorizeUsing" id="personal-access-token" ng-checked="AuthorizeUsing == 'PersonalAccessToken'"/>
-            <label for="personal-access-token">Personal Access Token</label>
-
-            <input value="UserAccessToken" type="radio" ng-model="AuthorizeUsing" ng-checked="AuthorizeUsing == 'UserAccessToken'" id="users-access-token" ng-click="PersonalAccessToken = ''"/>
-            <label for="users-access-token">User's Access Token</label>
-            <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AuthorizeUsing].$error.server}" ng-show="GOINPUTNAME[AuthorizeUsing].$error.server">{{GOINPUTNAME[AuthorizeUsing].$error.server}}</span>
-        </div>
-
-    </div>
-
-    <div class="form_item_block" ng-show="AuthorizeUsing == 'PersonalAccessToken'" ng-init="PersonalAccessToken = (PersonalAccessToken || '')">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[PersonalAccessToken].$error.server}">Personal Access Token:<span class='asterix'>*</span>
+    <div class="form_item_block">
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[PersonalAccessToken].$error.server}">Personal Access
+            Token:<span class='asterix'>*</span>
             <div class="tooltip-info">
               <span class="tooltip-content">
                 Personal access token with read:org permission is required.
               </span>
             </div>
         </label>
-        <input ng-class="{'is-invalid-input': GOINPUTNAME[PersonalAccessToken].$error.server}" type="password" ng-model="PersonalAccessToken" ng-required="true"/>
-        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[PersonalAccessToken].$error.server}" ng-show="GOINPUTNAME[PersonalAccessToken].$error.server">{{GOINPUTNAME[PersonalAccessToken].$error.server}}</span>
+        <input ng-class="{'is-invalid-input': GOINPUTNAME[PersonalAccessToken].$error.server}" type="password"
+               ng-model="PersonalAccessToken" ng-required="true"/>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[PersonalAccessToken].$error.server}"
+              ng-show="GOINPUTNAME[PersonalAccessToken].$error.server">{{GOINPUTNAME[PersonalAccessToken].$error.server}}</span>
     </div>
 
     <div class="form_item_block">
-        <label ng-class="{'is-invalid-label': GOINPUTNAME[AllowedOrganizations].$error.server}">GitHub Organizations <small>(Enter comma-separated)</small>:
+        <label ng-class="{'is-invalid-label': GOINPUTNAME[AllowedOrganizations].$error.server}">GitHub Organizations
+            <small>(Enter comma-separated)</small>
+            :
             <div class="tooltip-info">
               <span class="tooltip-content">
                 Organizations simplify management of group-owned repositories (for example: your company's code), expand on our permissions system, and help focus your GitHub workflow for business and large open source projects.
               </span>
             </div>
         </label>
-        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[AllowedOrganizations].$error.server}" rows="5" ng-model="AllowedOrganizations" ng-required="true"></textarea>
-        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AllowedOrganizations].$error.server}" ng-show="GOINPUTNAME[AllowedOrganizations].$error.server">{{GOINPUTNAME[AllowedOrganizations].$error.server}}</span>
+        <textarea ng-class="{'is-invalid-input': GOINPUTNAME[AllowedOrganizations].$error.server}" rows="5"
+                  ng-model="AllowedOrganizations" ng-required="true"></textarea>
+        <span class="form_error form-error" ng-class="{'is-visible': GOINPUTNAME[AllowedOrganizations].$error.server}"
+              ng-show="GOINPUTNAME[AllowedOrganizations].$error.server">{{GOINPUTNAME[AllowedOrganizations].$error.server}}</span>
     </div>
 
 </div>

--- a/src/test/java/cd/go/authorization/github/GitHubAuthenticatorTest.java
+++ b/src/test/java/cd/go/authorization/github/GitHubAuthenticatorTest.java
@@ -30,7 +30,6 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -79,7 +78,7 @@ public class GitHubAuthenticatorTest {
 
         when(gitHub.getMyself()).thenReturn(myself);
         when(gitHubConfiguration.organizationsAllowed()).thenReturn(allowedOrganizations);
-        when(membershipChecker.isAMemberOfAtLeastOneOrganization(any(LoggedInUserInfo.class), eq(authConfig), eq(allowedOrganizations))).thenReturn(true);
+        when(membershipChecker.isAMemberOfAtLeastOneOrganization(eq(myself), eq(authConfig), eq(allowedOrganizations))).thenReturn(true);
 
         final LoggedInUserInfo loggedInUserInfo = authenticator.authenticate(tokenInfo, authConfig);
 
@@ -93,7 +92,7 @@ public class GitHubAuthenticatorTest {
 
         when(gitHub.getMyself()).thenReturn(myself);
         when(gitHubConfiguration.organizationsAllowed()).thenReturn(allowedOrganizations);
-        when(membershipChecker.isAMemberOfAtLeastOneOrganization(any(LoggedInUserInfo.class), eq(authConfig), eq(allowedOrganizations))).thenReturn(false);
+        when(membershipChecker.isAMemberOfAtLeastOneOrganization(eq(myself), eq(authConfig), eq(allowedOrganizations))).thenReturn(false);
 
         final LoggedInUserInfo loggedInUserInfo = authenticator.authenticate(tokenInfo, authConfig);
 

--- a/src/test/java/cd/go/authorization/github/MembershipCheckerTest.java
+++ b/src/test/java/cd/go/authorization/github/MembershipCheckerTest.java
@@ -62,8 +62,6 @@ public class MembershipCheckerTest {
         final GHOrganization organization = mock(GHOrganization.class);
 
         when(organization.getName()).thenReturn("organization-foo");
-        when(gitHubConfiguration.gitHubClient()).thenReturn(gitHub);
-        when(gitHubConfiguration.authorizeUsingPersonalAccessToken()).thenReturn(true);
         when(gitHub.getOrganization("organization-foo")).thenReturn(organization);
         when(organization.hasMember(ghUser)).thenReturn(true);
 
@@ -77,8 +75,6 @@ public class MembershipCheckerTest {
         final GHOrganization organization = mock(GHOrganization.class);
 
         when(organization.getName()).thenReturn("organization-baz");
-        when(gitHubConfiguration.gitHubClient()).thenReturn(gitHub);
-        when(gitHubConfiguration.authorizeUsingPersonalAccessToken()).thenReturn(true);
         when(gitHub.getOrganization("organization-foo")).thenReturn(organization);
         when(organization.hasMember(ghUser)).thenReturn(false);
 
@@ -96,9 +92,7 @@ public class MembershipCheckerTest {
         when(organization.getName()).thenReturn("organization-foo");
         when(organization.getTeams()).thenReturn(singletonMap("TeamX", team));
         when(gitHub.getOrganization("organization-foo")).thenReturn(organization);
-        when(gitHubConfiguration.gitHubClient()).thenReturn(gitHub);
         when(team.hasMember(ghUser)).thenReturn(true);
-        when(gitHubConfiguration.authorizeUsingPersonalAccessToken()).thenReturn(true);
 
         final boolean aMemberOfAtLeastOneTeamOfOrganization = membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(ghUser, authConfig, singletonMap("organization-foo", asList("teamx")));
 
@@ -123,10 +117,7 @@ public class MembershipCheckerTest {
         when(teamX.hasMember(ghUser)).thenReturn(false);
 
         when(teamY.getName()).thenReturn("TeamY");
-        when(teamX.hasMember(ghUser)).thenReturn(true);
-
-        when(gitHubConfiguration.gitHubClient()).thenReturn(gitHub);
-        when(gitHubConfiguration.authorizeUsingPersonalAccessToken()).thenReturn(true);
+        when(teamX.hasMember(ghUser)).thenReturn(true);;
 
         final boolean aMemberOfAtLeastOneTeamOfOrganization = membershipChecker.isAMemberOfAtLeastOneTeamOfOrganization(ghUser, authConfig, singletonMap("organization-foo", asList("TeamX")));
 

--- a/src/test/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/AuthConfigValidateRequestExecutorTest.java
@@ -35,13 +35,13 @@ public class AuthConfigValidateRequestExecutorTest {
     private GoPluginApiRequest request;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         request = mock(GoPluginApiRequest.class);
     }
 
     @Test
     public void shouldValidateMandatoryKeys() throws Exception {
-        when(request.requestBody()).thenReturn(new Gson().toJson(singletonMap("AuthorizeUsing", "UserAccessToken")));
+        when(request.requestBody()).thenReturn(new Gson().toJson(singletonMap("AllowedOrganizations", "Foo")));
 
         GoPluginApiResponse response = AuthConfigValidateRequest.from(request).execute();
         String json = response.responseBody();
@@ -54,6 +54,10 @@ public class AuthConfigValidateRequestExecutorTest {
                 "  {\n" +
                 "    \"key\": \"ClientSecret\",\n" +
                 "    \"message\": \"ClientSecret must not be blank.\"\n" +
+                "  },\n" +
+                "  {\n" +
+                "    \"key\": \"PersonalAccessToken\",\n" +
+                "    \"message\": \"PersonalAccessToken must not be blank.\"\n" +
                 "  }\n" +
                 "]";
 
@@ -67,7 +71,7 @@ public class AuthConfigValidateRequestExecutorTest {
                 "  \"AllowedOrganizations\": \"example-1,example-2\",\n" +
                 "  \"AuthenticateWith\": \"GitHubEnterprise\",\n" +
                 "  \"ClientSecret\": \"client-secret\",\n" +
-                "  \"AuthorizeUsing\": \"UserAccessToken\"\n" +
+                "  \"PersonalAccessToken\": \"Foobar\"\n" +
                 "}");
 
         GoPluginApiResponse response = AuthConfigValidateRequest.from(request).execute();
@@ -83,14 +87,13 @@ public class AuthConfigValidateRequestExecutorTest {
     }
 
     @Test
-    public void shouldValidatePersonalAccessTokenWhenUsePersonalAccessTokenIsSetToTrue() throws Exception {
+    public void shouldValidatePersonalAccessToken() throws Exception {
         final GitHubConfiguration gitHubConfiguration = GitHubConfiguration.fromJSON("{\n" +
                 "  \"ClientId\": \"client-id\",\n" +
                 "  \"AllowedOrganizations\": \"example-1,example-2\",\n" +
                 "  \"AuthenticateWith\": \"GitHubEnterprise\",\n" +
                 "  \"GitHubEnterpriseUrl\": \"https://enterprise.url\",\n" +
-                "  \"ClientSecret\": \"client-secret\",\n" +
-                "  \"AuthorizeUsing\": \"PersonalAccessToken\"\n" +
+                "  \"ClientSecret\": \"client-secret\"" +
                 "}");
 
         when(request.requestBody()).thenReturn(gitHubConfiguration.toJSON());

--- a/src/test/java/cd/go/authorization/github/executors/GetAuthConfigMetadataRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetAuthConfigMetadataRequestExecutorTest.java
@@ -80,16 +80,9 @@ public class GetAuthConfigMetadataRequestExecutorTest {
                 "    }\n" +
                 "  },\n" +
                 "  {\n" +
-                "    \"key\": \"AuthorizeUsing\",\n" +
-                "    \"metadata\": {\n" +
-                "      \"required\": true,\n" +
-                "      \"secure\": false\n" +
-                "    }\n" +
-                "  },\n" +
-                "  {\n" +
                 "    \"key\": \"PersonalAccessToken\",\n" +
                 "    \"metadata\": {\n" +
-                "      \"required\": false,\n" +
+                "      \"required\": true,\n" +
                 "      \"secure\": true\n" +
                 "    }\n" +
                 "  }\n" +

--- a/src/test/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutorTest.java
@@ -21,10 +21,11 @@ import cd.go.authorization.github.annotation.ProfileMetadata;
 import cd.go.authorization.github.models.GitHubConfiguration;
 import cd.go.authorization.github.utils.Util;
 import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.junit.Test;
 
-import java.util.HashMap;
+import java.lang.reflect.Type;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.*;
@@ -36,12 +37,14 @@ public class GetAuthConfigViewRequestExecutorTest {
     public void shouldRenderTheTemplateInJSON() throws Exception {
         GoPluginApiResponse response = new GetAuthConfigViewRequestExecutor().execute();
         assertThat(response.responseCode(), is(200));
-        Map<String, String> hashSet = new Gson().fromJson(response.responseBody(), HashMap.class);
+        Type type = new TypeToken<Map<String, String>>() {
+        }.getType();
+        Map<String, String> hashSet = new Gson().fromJson(response.responseBody(), type);
         assertThat(hashSet, hasEntry("template", Util.readResource("/auth-config.template.html")));
     }
 
     @Test
-    public void allFieldsShouldBePresentInView() throws Exception {
+    public void allFieldsShouldBePresentInView() {
         String template = Util.readResource("/auth-config.template.html");
 
         for (ProfileMetadata field : MetadataHelper.getMetadata(GitHubConfiguration.class)) {

--- a/src/test/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetAuthConfigViewRequestExecutorTest.java
@@ -23,18 +23,22 @@ import cd.go.authorization.github.utils.Util;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 import org.junit.Test;
 
 import java.lang.reflect.Type;
 import java.util.Map;
 
+import static java.lang.String.*;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.assertThat;
 
 public class GetAuthConfigViewRequestExecutorTest {
 
     @Test
-    public void shouldRenderTheTemplateInJSON() throws Exception {
+    public void shouldRenderTheTemplateInJSON() {
         GoPluginApiResponse response = new GetAuthConfigViewRequestExecutor().execute();
         assertThat(response.responseCode(), is(200));
         Type type = new TypeToken<Map<String, String>>() {
@@ -47,12 +51,21 @@ public class GetAuthConfigViewRequestExecutorTest {
     public void allFieldsShouldBePresentInView() {
         String template = Util.readResource("/auth-config.template.html");
 
+        final Document document = Jsoup.parse(template);
+
         for (ProfileMetadata field : MetadataHelper.getMetadata(GitHubConfiguration.class)) {
-            assertThat(template, containsString("ng-model=\"" + field.getKey() + "\""));
-            assertThat(template, containsString("<span class=\"form_error form-error\" ng-class=\"{'is-visible': GOINPUTNAME[" +
-                    field.getKey() + "].$error.server}\" ng-show=\"GOINPUTNAME[" +
-                    field.getKey() + "].$error.server\">{{GOINPUTNAME[" +
-                    field.getKey() + "].$error.server}}</span>"));
+            final Elements inputFieldForKey = document.getElementsByAttributeValue("ng-model", field.getKey());
+            int elementCount = field.getKey().equalsIgnoreCase("AuthenticateWith") ? 2 : 1;
+            assertThat(format("Should have only one ng-model for %s", inputFieldForKey), inputFieldForKey, hasSize(elementCount));
+
+            final Elements spanToShowError = document.getElementsByAttributeValue("ng-class", "{'is-visible': GOINPUTNAME[" + field.getKey() + "].$error.server}");
+            assertThat(spanToShowError, hasSize(1));
+            assertThat(spanToShowError.attr("ng-show"), is("GOINPUTNAME[" + field.getKey() + "].$error.server"));
+            assertThat(spanToShowError.text(), is("{{GOINPUTNAME[" + field.getKey() + "].$error.server}}"));
         }
+
+        final Elements inputs = document.select("textarea,input,select");
+        //AuthenticateWith is coming twice as it is radio button
+        assertThat(inputs, hasSize(MetadataHelper.getMetadata(GitHubConfiguration.class).size() + 1));
     }
 }

--- a/src/test/java/cd/go/authorization/github/executors/GetCapabilitiesRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetCapabilitiesRequestExecutorTest.java
@@ -29,7 +29,8 @@ public class GetCapabilitiesRequestExecutorTest {
         String expectedJSON = "{\n" +
                 "    \"supported_auth_type\":\"web\",\n" +
                 "    \"can_authorize\":true,\n" +
-                "    \"can_search\":true\n" +
+                "    \"can_search\":true,\n" +
+                "    \"can_get_user_roles\":true\n" +
                 "}";
 
         JSONAssert.assertEquals(expectedJSON, response.responseBody(), true);

--- a/src/test/java/cd/go/authorization/github/executors/GetRolesExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/GetRolesExecutorTest.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import cd.go.authorization.github.GitHubAuthorizer;
+import cd.go.authorization.github.GitHubClientBuilder;
+import cd.go.authorization.github.models.AuthConfig;
+import cd.go.authorization.github.models.GitHubConfiguration;
+import cd.go.authorization.github.models.Role;
+import cd.go.authorization.github.requests.GetRolesRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.mockito.InOrder;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.*;
+
+public class GetRolesExecutorTest {
+
+    private GetRolesRequest request;
+    private GetRolesExecutor executor;
+    private GitHubAuthorizer authorizer;
+    private GitHubClientBuilder clientBuilder;
+
+    @Before
+    public void setUp() {
+        request = mock(GetRolesRequest.class);
+        authorizer = mock(GitHubAuthorizer.class);
+        clientBuilder = mock(GitHubClientBuilder.class);
+        AuthConfig authConfig = mock(AuthConfig.class);
+        when(request.getAuthConfig()).thenReturn(authConfig);
+        when(request.getUsername()).thenReturn("bob");
+        when(authConfig.gitHubConfiguration()).thenReturn(mock(GitHubConfiguration.class));
+
+        executor = new GetRolesExecutor(request, authorizer, clientBuilder);
+    }
+
+    @Test
+    public void shouldReturnEmptyResponseIfThereAreNoRolesProvidedFromRequest() throws Exception {
+        when(clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration())).thenReturn(mock(GitHub.class));
+
+        GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode(), is(200));
+        JSONAssert.assertEquals("[]", response.responseBody(), true);
+        verifyZeroInteractions(authorizer);
+        verifyZeroInteractions(clientBuilder);
+    }
+
+    @Test
+    public void shouldReturnSuccessResponseWithRoles() throws IOException, JSONException {
+        GitHub gitHub = mock(GitHub.class);
+        GHUser ghUser = mock(GHUser.class);
+
+        when(clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration())).thenReturn(gitHub);
+        when(gitHub.getUser("bob")).thenReturn(ghUser);
+        when(request.getRoles()).thenReturn(rolesWithName("blackbird", "super-admin", "view"));
+        when(authorizer.authorize(ghUser, request.getAuthConfig(), request.getRoles())).thenReturn(Arrays.asList("blackbird", "super-admin"));
+
+        GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode(), is(200));
+        JSONAssert.assertEquals("[\"blackbird\",\"super-admin\"]", response.responseBody(), true);
+
+        InOrder inOrder = inOrder(clientBuilder, gitHub, authorizer);
+        inOrder.verify(clientBuilder).build(null, request.getAuthConfig().gitHubConfiguration());
+        inOrder.verify(gitHub).getUser(request.getUsername());
+        inOrder.verify(authorizer).authorize(ghUser, request.getAuthConfig(), request.getRoles());
+    }
+
+    @Test
+    public void shouldReturnErrorResponseWhenUserWithProvidedUsernameNotFound() throws IOException {
+        GitHub gitHub = mock(GitHub.class);
+
+        when(clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration())).thenReturn(gitHub);
+        when(gitHub.getUser("bob")).thenReturn(null);
+        when(request.getRoles()).thenReturn(rolesWithName("blackbird", "super-admin", "view"));
+
+        GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode(), is(500));
+
+        InOrder inOrder = inOrder(clientBuilder, gitHub);
+        inOrder.verify(clientBuilder).build(null, request.getAuthConfig().gitHubConfiguration());
+        inOrder.verify(gitHub).getUser(request.getUsername());
+        verifyZeroInteractions(authorizer);
+    }
+
+    private Role roleWithName(String name) {
+        return Role.fromJSON("{\"name\":\"" + name + "\"}");
+    }
+
+    private List<Role> rolesWithName(String... names) {
+        return Arrays.stream(names).map(this::roleWithName).collect(Collectors.toList());
+    }
+}
+

--- a/src/test/java/cd/go/authorization/github/executors/SearchUsersRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/SearchUsersRequestExecutorTest.java
@@ -1,41 +1,50 @@
 package cd.go.authorization.github.executors;
 
 import cd.go.authorization.github.GitHubClientBuilder;
-import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import cd.go.authorization.github.models.AuthConfig;
+import cd.go.authorization.github.models.GitHubConfiguration;
+import cd.go.authorization.github.requests.SearchUsersRequest;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import org.junit.Before;
 import org.junit.Test;
 import org.kohsuke.github.*;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.util.Arrays;
+import java.util.Collections;
 
+import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 public class SearchUsersRequestExecutorTest {
 
-    private GoPluginApiRequest request;
+    private SearchUsersRequest request;
     private GitHubClientBuilder clientBuilder;
     private GitHub gitHub;
     private GHUserSearchBuilder userSearchBuilder;
+    private SearchUsersRequestExecutor executor;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         clientBuilder = mock(GitHubClientBuilder.class);
-        request = mock(GoPluginApiRequest.class);
+        request = mock(SearchUsersRequest.class);
         gitHub = mock(GitHub.class);
         userSearchBuilder = mock(GHUserSearchBuilder.class);
+
+        executor = new SearchUsersRequestExecutor(request, clientBuilder);
     }
 
     @Test
     public void shouldSearchForUsersThatMatchTheSearchTerm() throws Exception {
-        SearchUsersRequestExecutor searchUsersRequestExecutor = new SearchUsersRequestExecutor(request, clientBuilder);
-        when(request.requestBody()).thenReturn(requestJson());
-        when(clientBuilder.build(eq("personalAccessToken"), any())).thenReturn(gitHub);
+        AuthConfig authConfig = mock(AuthConfig.class);
+        when(authConfig.gitHubConfiguration()).thenReturn(mock(GitHubConfiguration.class));
+
+        when(request.getSearchTerm()).thenReturn("tom");
+        when(request.getAuthConfigs()).thenReturn(singletonList(authConfig));
+        when(clientBuilder.build(null, request.getAuthConfigs().get(0).gitHubConfiguration()))
+                .thenReturn(gitHub);
         when(gitHub.searchUsers()).thenReturn(userSearchBuilder);
         when(userSearchBuilder.q("tom")).thenReturn(userSearchBuilder);
         PagedSearchIterable pageSearchIterable = mock(PagedSearchIterable.class);
@@ -44,11 +53,12 @@ public class SearchUsersRequestExecutorTest {
         when(userSearchBuilder.list()).thenReturn(pageSearchIterable);
         when(pageSearchIterable.withPageSize(10)).thenReturn(pageSearchIterable);
         when(pageSearchIterable.iterator()).thenReturn(pagedIterator);
-        when(pagedIterator.nextPage()).thenReturn(Arrays.asList(githubUser));
+        when(pagedIterator.nextPage()).thenReturn(singletonList(githubUser));
         when(githubUser.getLogin()).thenReturn("tom01");
         when(githubUser.getName()).thenReturn("Tom NoLastname");
         when(githubUser.getEmail()).thenReturn("tom@gocd.org");
-        GoPluginApiResponse response = searchUsersRequestExecutor.execute();
+
+        GoPluginApiResponse response = executor.execute();
 
         assertThat(response.responseCode(), is(200));
         JSONAssert.assertEquals("[{\"username\":\"tom01\", \"display_name\": \"Tom NoLastname\", \"email\": \"tom@gocd.org\"}]", response.responseBody(), true);
@@ -56,38 +66,12 @@ public class SearchUsersRequestExecutorTest {
 
     @Test
     public void shouldNotPerformSearchIfAuthConfigsIsEmpty() throws Exception {
-        SearchUsersRequestExecutor searchUsersRequestExecutor = new SearchUsersRequestExecutor(request, clientBuilder);
-        when(request.requestBody()).thenReturn(requestJsonWithEmptyAuthConfigs());
-        GoPluginApiResponse response = searchUsersRequestExecutor.execute();
+        when(request.getAuthConfigs()).thenReturn(Collections.emptyList());
+
+        GoPluginApiResponse response = executor.execute();
 
         verify(clientBuilder, never()).build(anyString(), any());
         assertThat(response.responseCode(), is(200));
         JSONAssert.assertEquals("[]", response.responseBody(), false);
     }
-
-
-    private String requestJson() {
-        return "{\n" +
-                "  \"search_term\": \"tom\",\n" +
-                "  \"auth_configs\": [\n" +
-                "    {\n" +
-                "      \"id\": \"github\",\n" +
-                "      \"configuration\": {\n" +
-                "        \"PersonalAccessToken\": \"personalAccessToken\",\n" +
-                "        \"AuthenticateWith\": \"GitHub\",\n" +
-                "        \"ClientId\": \"clientId\"," +
-                "        \"ClientSecret\": \"clientSecret\"" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
-    }
-
-    private String requestJsonWithEmptyAuthConfigs() {
-        return "{\n" +
-                "  \"search_term\": \"tom\",\n" +
-                "  \"auth_configs\": []\n" +
-                "}";
-    }
-
 }

--- a/src/test/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutorTest.java
@@ -27,6 +27,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.kohsuke.github.GHMyself;
 import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Collections;
@@ -76,12 +77,14 @@ public class UserAuthenticationRequestExecutorTest {
         final User user = new User("bford", "Bob", "bford@example.com");
         final LoggedInUserInfo loggedInUserInfo = mock(LoggedInUserInfo.class);
         final TokenInfo tokenInfo = new TokenInfo("access-token", "token-type", "user:email,org:read");
+        final GHMyself ghUser = mock(GHMyself.class);
 
         when(loggedInUserInfo.getUser()).thenReturn(user);
+        when(loggedInUserInfo.getGitHubUser()).thenReturn(ghUser);
         when(request.authConfigs()).thenReturn(Collections.singletonList(authConfig));
         when(request.tokenInfo()).thenReturn(tokenInfo);
         when(authenticator.authenticate(tokenInfo, authConfig)).thenReturn(loggedInUserInfo);
-        when(authorizer.authorize(eq(loggedInUserInfo), eq(authConfig), anyList())).thenReturn(Collections.emptyList());
+        when(authorizer.authorize(eq(ghUser), eq(authConfig), anyList())).thenReturn(Collections.emptyList());
 
         final GoPluginApiResponse response = executor.execute();
 
@@ -104,13 +107,15 @@ public class UserAuthenticationRequestExecutorTest {
         final LoggedInUserInfo loggedInUserInfo = mock(LoggedInUserInfo.class);
         final User user = new User("bford", "Bob", "bford@example.com");
         final Role role = mock(Role.class);
+        final GHMyself ghUser = mock(GHMyself.class);
 
         when(loggedInUserInfo.getUser()).thenReturn(user);
         when(request.authConfigs()).thenReturn(Collections.singletonList(authConfig));
         when(request.roles()).thenReturn(Collections.singletonList(role));
         when(request.tokenInfo()).thenReturn(tokenInfo);
         when(authenticator.authenticate(tokenInfo, authConfig)).thenReturn(loggedInUserInfo);
-        when(authorizer.authorize(loggedInUserInfo, authConfig, request.roles())).thenReturn(Collections.singletonList("admin"));
+        when(loggedInUserInfo.getGitHubUser()).thenReturn(ghUser);
+        when(authorizer.authorize(ghUser, authConfig, request.roles())).thenReturn(Collections.singletonList("admin"));
 
         final GoPluginApiResponse response = executor.execute();
 

--- a/src/test/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/UserAuthenticationRequestExecutorTest.java
@@ -59,7 +59,7 @@ public class UserAuthenticationRequestExecutorTest {
         authenticator = mock(GitHubAuthenticator.class);
         gitHubClientBuilder = mock(GitHubClientBuilder.class);
 
-        executor = new UserAuthenticationRequestExecutor(request, gitHubClientBuilder, authenticator, authorizer);
+        executor = new UserAuthenticationRequestExecutor(request, authenticator, authorizer);
     }
 
     @Test

--- a/src/test/java/cd/go/authorization/github/executors/ValidateUserRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/ValidateUserRequestExecutorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import cd.go.authorization.github.GitHubClientBuilder;
+import cd.go.authorization.github.models.AuthConfig;
+import cd.go.authorization.github.models.GitHubConfiguration;
+import cd.go.authorization.github.requests.ValidateUserRequest;
+import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
+import org.junit.Before;
+import org.junit.Test;
+import org.kohsuke.github.GHUser;
+import org.kohsuke.github.GitHub;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ValidateUserRequestExecutorTest {
+
+    private ValidateUserRequestExecutor executor;
+    private ValidateUserRequest request;
+    private GitHubClientBuilder clientBuilder;
+
+    @Before
+    public void setUp() {
+        request = mock(ValidateUserRequest.class);
+        clientBuilder = mock(GitHubClientBuilder.class);
+
+        AuthConfig authConfig = mock(AuthConfig.class);
+        when(request.getAuthConfig()).thenReturn(authConfig);
+        when(authConfig.gitHubConfiguration()).thenReturn(mock(GitHubConfiguration.class));
+
+        executor = new ValidateUserRequestExecutor(request, clientBuilder);
+    }
+
+    @Test
+    public void shouldReturnSuccessResponseWhenUserIsAValidUser() throws Exception {
+        GitHub gitHub = mock(GitHub.class);
+        when(clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration()))
+                .thenReturn(gitHub);
+        when(request.getUsername()).thenReturn("bob");
+        when(gitHub.getUser("bob")).thenReturn(mock(GHUser.class));
+
+        GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode(), is(200));
+        JSONAssert.assertEquals("", response.responseBody(), true);
+    }
+
+    @Test
+    public void shouldReturnErrorResponseWhenUserIsNotAValidUser() throws Exception {
+        GitHub gitHub = mock(GitHub.class);
+        when(clientBuilder.build(null, request.getAuthConfig().gitHubConfiguration()))
+                .thenReturn(gitHub);
+        when(request.getUsername()).thenReturn("bob");
+        when(gitHub.getUser("bob")).thenReturn(null);
+
+        GoPluginApiResponse response = executor.execute();
+
+        assertThat(response.responseCode(), is(500));
+    }
+}

--- a/src/test/java/cd/go/authorization/github/executors/VerifyConnectionRequestExecutorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/VerifyConnectionRequestExecutorTest.java
@@ -36,7 +36,7 @@ public class VerifyConnectionRequestExecutorTest {
     private VerifyConnectionRequestExecutor executor;
 
     @Before
-    public void setup() throws Exception {
+    public void setup() {
         request = mock(VerifyConnectionRequest.class);
         providerManager = mock(GitHubClientBuilder.class);
 
@@ -50,8 +50,11 @@ public class VerifyConnectionRequestExecutorTest {
         GoPluginApiResponse response = executor.execute();
 
         String expectedJSON = "{\n" +
-                "  \"message\": \"Validation failed for the given Auth Config\",\n" +
                 "  \"errors\": [\n" +
+                "    {\n" +
+                "      \"key\": \"PersonalAccessToken\",\n" +
+                "      \"message\": \"PersonalAccessToken must not be blank.\"\n" +
+                "    },\n" +
                 "    {\n" +
                 "      \"key\": \"ClientId\",\n" +
                 "      \"message\": \"ClientId must not be blank.\"\n" +
@@ -61,6 +64,7 @@ public class VerifyConnectionRequestExecutorTest {
                 "      \"message\": \"ClientSecret must not be blank.\"\n" +
                 "    }\n" +
                 "  ],\n" +
+                "  \"message\": \"Validation failed for the given Auth Config\",\n" +
                 "  \"status\": \"validation-failed\"\n" +
                 "}";
 

--- a/src/test/java/cd/go/authorization/github/models/GitHubConfigurationTest.java
+++ b/src/test/java/cd/go/authorization/github/models/GitHubConfigurationTest.java
@@ -25,12 +25,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 
 public class GitHubConfigurationTest {
 
     @Test
-    public void shouldDeserializeGitHubConfiguration() throws Exception {
+    public void shouldDeserializeGitHubConfiguration() {
         final GitHubConfiguration gitHubConfiguration = GitHubConfiguration.fromJSON("{\n" +
                 "  \"ClientId\": \"client-id\",\n" +
                 "  \"AllowedOrganizations\": \"example-1,example-2\",\n" +
@@ -46,7 +45,6 @@ public class GitHubConfigurationTest {
         assertThat(gitHubConfiguration.organizationsAllowed(), contains("example-1", "example-2"));
         assertThat(gitHubConfiguration.gitHubEnterpriseUrl(), is("https://enterprise.url"));
         assertThat(gitHubConfiguration.authenticateWith(), is(AuthenticateWith.GITHUB_ENTERPRISE));
-        assertTrue(gitHubConfiguration.authorizeUsingPersonalAccessToken());
         assertThat(gitHubConfiguration.personalAccessToken(), is("personal-access-token"));
     }
 
@@ -60,8 +58,7 @@ public class GitHubConfigurationTest {
                 "  \"ClientSecret\": \"client-secret\",\n" +
                 "  \"AuthenticateWith\": \"GitHubEnterprise\",\n" +
                 "  \"GitHubEnterpriseUrl\": \"http://enterprise.url\",\n" +
-                "  \"AllowedOrganizations\": \"example-1\",\n" +
-                "  \"AuthorizeUsing\": PersonalAccessToken\n" +
+                "  \"AllowedOrganizations\": \"example-1\"\n" +
                 "}";
 
         JSONAssert.assertEquals(expectedJSON, gitHubConfiguration.toJSON(), true);
@@ -69,7 +66,7 @@ public class GitHubConfigurationTest {
     }
 
     @Test
-    public void shouldConvertConfigurationToProperties() throws Exception {
+    public void shouldConvertConfigurationToProperties() {
         GitHubConfiguration gitHubConfiguration = new GitHubConfiguration("client-id", "client-secret", AuthenticateWith.GITHUB_ENTERPRISE, "http://enterprise.url", "example-1");
 
         final Map<String, String> properties = gitHubConfiguration.toProperties();

--- a/src/test/java/cd/go/authorization/github/requests/GetRolesRequestTest.java
+++ b/src/test/java/cd/go/authorization/github/requests/GetRolesRequestTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.requests;
+
+import cd.go.authorization.github.executors.GetRolesExecutor;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class GetRolesRequestTest {
+    @Test
+    public void shouldParseRequest() {
+        GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
+        when(apiRequest.requestBody()).thenReturn("{\n" +
+                "  \"auth_config\": {\n" +
+                "    \"configuration\": {\n" +
+                "      \"AllowedOrganizations\": \"\",\n" +
+                "      \"AuthenticateWith\": \"GitHub\",\n" +
+                "      \"AuthorizeUsing\": \"PersonalAccessToken\",\n" +
+                "      \"ClientId\": \"Foo\",\n" +
+                "      \"ClientSecret\": \"bar\",\n" +
+                "      \"GitHubEnterpriseUrl\": \"\",\n" +
+                "      \"PersonalAccessToken\": \"Baz\"\n" +
+                "    },\n" +
+                "    \"id\": \"GitHub\"\n" +
+                "  },\n" +
+                "   \"role_configs\": [],\n" +
+                "  \"username\": \"bob\"\n" +
+                "}");
+
+        GetRolesRequest request = (GetRolesRequest) GetRolesRequest.from(apiRequest);
+
+        assertThat(request.getUsername(), is("bob"));
+        assertThat(request.getAuthConfig().getId(), is("GitHub"));
+        assertThat(request.getRoles(), hasSize(0));
+    }
+
+    @Test
+    public void shouldReturnValidExecutor() {
+        GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
+        when(apiRequest.requestBody()).thenReturn("{\n" +
+                "  \"auth_config\": {\n" +
+                "    \"configuration\": {\n" +
+                "      \"AllowedOrganizations\": \"\",\n" +
+                "      \"AuthenticateWith\": \"GitHub\",\n" +
+                "      \"AuthorizeUsing\": \"PersonalAccessToken\",\n" +
+                "      \"ClientId\": \"Foo\",\n" +
+                "      \"ClientSecret\": \"bar\",\n" +
+                "      \"GitHubEnterpriseUrl\": \"\",\n" +
+                "      \"PersonalAccessToken\": \"Baz\"\n" +
+                "    },\n" +
+                "    \"id\": \"GitHub\"\n" +
+                "  },\n" +
+                "   \"role_configs\": [],\n" +
+                "  \"username\": \"bob\"\n" +
+                "}");
+
+        GetRolesRequest request = (GetRolesRequest) GetRolesRequest.from(apiRequest);
+        assertThat(request.executor() instanceof GetRolesExecutor, is(true));
+    }
+}

--- a/src/test/java/cd/go/authorization/github/requests/SearchUsersRequestTest.java
+++ b/src/test/java/cd/go/authorization/github/requests/SearchUsersRequestTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.requests;
+
+import cd.go.authorization.github.executors.SearchUsersRequestExecutor;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class SearchUsersRequestTest {
+    @Test
+    public void shouldParseRequest() {
+        GoPluginApiRequest request = mock(GoPluginApiRequest.class);
+        when(request.requestBody()).thenReturn("{\n" +
+                "  \"search_term\": \"tom\",\n" +
+                "  \"auth_configs\": [\n" +
+                "    {\n" +
+                "      \"id\": \"github\",\n" +
+                "      \"configuration\": {\n" +
+                "        \"PersonalAccessToken\": \"personalAccessToken\",\n" +
+                "        \"AuthenticateWith\": \"GitHub\",\n" +
+                "        \"ClientId\": \"clientId\"," +
+                "        \"ClientSecret\": \"clientSecret\"" +
+                "      }\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}");
+
+        SearchUsersRequest searchUsersRequest = SearchUsersRequest.from(request);
+
+        assertThat(searchUsersRequest.getSearchTerm(), is("tom"));
+        assertThat(searchUsersRequest.getAuthConfigs(), hasSize(1));
+    }
+
+    @Test
+    public void shouldReturnSearchUsersRequestExecutor() {
+        GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
+        when(apiRequest.requestBody()).thenReturn("{}");
+
+        Request request = SearchUsersRequest.from(apiRequest);
+
+        assertThat(request.executor() instanceof SearchUsersRequestExecutor, is(true));
+    }
+}

--- a/src/test/java/cd/go/authorization/github/requests/ValidateUserRequestTest.java
+++ b/src/test/java/cd/go/authorization/github/requests/ValidateUserRequestTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.requests;
+
+import cd.go.authorization.github.executors.ValidateUserRequestExecutor;
+import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ValidateUserRequestTest {
+
+    @Test
+    public void shouldParseGoAPIRequestToValidateUserRequest() {
+        GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
+        when(apiRequest.requestBody()).thenReturn("{\n" +
+                "  \"auth_config\": {\n" +
+                "    \"configuration\": {\n" +
+                "      \"AllowedOrganizations\": \"\",\n" +
+                "      \"AuthenticateWith\": \"GitHub\",\n" +
+                "      \"AuthorizeUsing\": \"PersonalAccessToken\",\n" +
+                "      \"ClientId\": \"Foo\",\n" +
+                "      \"ClientSecret\": \"bar\",\n" +
+                "      \"GitHubEnterpriseUrl\": \"\",\n" +
+                "      \"PersonalAccessToken\": \"Baz\"\n" +
+                "    },\n" +
+                "    \"id\": \"GitHub\"\n" +
+                "  },\n" +
+                "  \"username\": \"bob\"\n" +
+                "}");
+
+        ValidateUserRequest request = (ValidateUserRequest) ValidateUserRequest.from(apiRequest);
+
+        assertThat(request.getUsername(), is("bob"));
+        assertThat(request.getAuthConfig().getId(), is("GitHub"));
+    }
+
+    @Test
+    public void shouldReturnValidateUserExecutor() {
+        GoPluginApiRequest apiRequest = mock(GoPluginApiRequest.class);
+        when(apiRequest.requestBody()).thenReturn("{\n" +
+                "  \"auth_config\": {\n" +
+                "    \"configuration\": {\n" +
+                "      \"AllowedOrganizations\": \"\",\n" +
+                "      \"AuthenticateWith\": \"GitHub\",\n" +
+                "      \"AuthorizeUsing\": \"PersonalAccessToken\",\n" +
+                "      \"ClientId\": \"Foo\",\n" +
+                "      \"ClientSecret\": \"bar\",\n" +
+                "      \"GitHubEnterpriseUrl\": \"\",\n" +
+                "      \"PersonalAccessToken\": \"Baz\"\n" +
+                "    },\n" +
+                "    \"id\": \"GitHub\"\n" +
+                "  },\n" +
+                "  \"username\": \"bob\"\n" +
+                "}");
+
+        Request request = ValidateUserRequest.from(apiRequest);
+
+        assertThat(request.executor() instanceof ValidateUserRequestExecutor, is(true));
+    }
+}


### PR DESCRIPTION
- Added support for authorization extension v2
    - Updated `get_capabilities` API endpoint to use authorization extension v2
    - Now plugin implementes is-valid-user and get-user-role request

- Made personal access token mandatory

    - We need to access roles for the user based on username. This requires `personal access token` or `users access token`
      While serveing `get-user-roles` and `is-user-valid` request user plugin won;t get user access token. This will always
      requires personal access token to get necessary information from GitHub

 **_Note:_** 
         *1.This will break the plugin compatibility with existing configuration, in case if user has set use `users access token` to authenticate a user.*
         *2. The plugin will work with GoCD version 19.2.0 or above.*