### PR TITLE
Add support for generating and validated OAuth `state` parameter

### DIFF
--- a/src/main/java/cd/go/authorization/github/Constants.java
+++ b/src/main/java/cd/go/authorization/github/Constants.java
@@ -29,4 +29,6 @@ public interface Constants {
 
     // the identifier of this plugin
     GoPluginIdentifier PLUGIN_IDENTIFIER = new GoPluginIdentifier(EXTENSION_TYPE, Collections.singletonList(API_VERSION));
+
+    String AUTH_SESSION_STATE = "oauth2_state";
 }

--- a/src/main/java/cd/go/authorization/github/executors/FetchAccessTokenRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/FetchAccessTokenRequestExecutor.java
@@ -51,6 +51,8 @@ public class FetchAccessTokenRequestExecutor implements RequestExecutor {
             throw new IllegalArgumentException("Get Access Token] Expecting `code` in request params, but not received.");
         }
 
+        request.validateState();
+
         final AuthConfig authConfig = request.authConfigs().get(0);
         final GitHubConfiguration gitHubConfiguration = authConfig.gitHubConfiguration();
 

--- a/src/main/java/cd/go/authorization/github/executors/GetAuthorizationServerUrlRequestExecutor.java
+++ b/src/main/java/cd/go/authorization/github/executors/GetAuthorizationServerUrlRequestExecutor.java
@@ -16,6 +16,7 @@
 
 package cd.go.authorization.github.executors;
 
+import cd.go.authorization.github.Constants;
 import cd.go.authorization.github.exceptions.NoAuthorizationConfigurationException;
 import cd.go.authorization.github.models.AuthConfig;
 import cd.go.authorization.github.models.GitHubConfiguration;
@@ -24,7 +25,7 @@ import com.thoughtworks.go.plugin.api.response.DefaultGoPluginApiResponse;
 import com.thoughtworks.go.plugin.api.response.GoPluginApiResponse;
 import okhttp3.HttpUrl;
 
-import java.util.Collections;
+import java.util.Map;
 
 import static cd.go.authorization.github.GitHubPlugin.LOG;
 import static cd.go.authorization.github.utils.Util.GSON;
@@ -46,6 +47,7 @@ public class GetAuthorizationServerUrlRequestExecutor implements RequestExecutor
         final AuthConfig authConfig = request.authConfigs().get(0);
         final GitHubConfiguration gitHubConfiguration = authConfig.gitHubConfiguration();
 
+        String state = StateGenerator.generate();
         String authorizationServerUrl = HttpUrl.parse(gitHubConfiguration.apiUrl())
                 .newBuilder()
                 .addPathSegment("login")
@@ -54,9 +56,13 @@ public class GetAuthorizationServerUrlRequestExecutor implements RequestExecutor
                 .addQueryParameter("client_id", gitHubConfiguration.clientId())
                 .addQueryParameter("redirect_uri", request.callbackUrl())
                 .addQueryParameter("scope", gitHubConfiguration.scope())
+                .addQueryParameter("state", state)
                 .build().toString();
 
 
-        return DefaultGoPluginApiResponse.success(GSON.toJson(Collections.singletonMap("authorization_server_url", authorizationServerUrl)));
+        return DefaultGoPluginApiResponse.success(GSON.toJson(Map.of(
+                "authorization_server_url", authorizationServerUrl,
+                "auth_session", Map.of(Constants.AUTH_SESSION_STATE, state)
+        )));
     }
 }

--- a/src/main/java/cd/go/authorization/github/executors/StateGenerator.java
+++ b/src/main/java/cd/go/authorization/github/executors/StateGenerator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+public class StateGenerator {
+
+    private static final SecureRandom RANDOM = new SecureRandom();
+
+    public static String generate() {
+        byte[] bytes = new byte[32];
+        RANDOM.nextBytes(bytes);
+        return Base64.getUrlEncoder().encodeToString(bytes);
+    }
+}

--- a/src/main/java/cd/go/authorization/github/requests/FetchAccessTokenRequest.java
+++ b/src/main/java/cd/go/authorization/github/requests/FetchAccessTokenRequest.java
@@ -16,19 +16,31 @@
 
 package cd.go.authorization.github.requests;
 
+import cd.go.authorization.github.Constants;
+import cd.go.authorization.github.exceptions.AuthenticationException;
 import cd.go.authorization.github.executors.FetchAccessTokenRequestExecutor;
 import cd.go.authorization.github.executors.RequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
+import com.thoughtworks.go.plugin.api.logging.Logger;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
 
+import java.security.MessageDigest;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 
 public class FetchAccessTokenRequest extends Request {
+    private static final Logger LOGGER = Logger.getLoggerFor(FetchAccessTokenRequest.class);
+
     @Expose
     @SerializedName("auth_configs")
     private List<AuthConfig> authConfigs;
+
+    @Expose
+    @SerializedName("auth_session")
+    private Map<String, String> authSession;
 
     public static FetchAccessTokenRequest from(GoPluginApiRequest apiRequest) {
         return Request.from(apiRequest, FetchAccessTokenRequest.class);
@@ -38,8 +50,26 @@ public class FetchAccessTokenRequest extends Request {
         return authConfigs;
     }
 
+    public Map<String, String> authSession() {
+        return authSession;
+    }
+
     @Override
     public RequestExecutor executor() {
         return new FetchAccessTokenRequestExecutor(this);
+    }
+
+    public void validateState() {
+        // GoCD versions prior to 23.2.0 don't return state, so we can't validate it, this is for backward compatibility
+        if (authSession == null) {
+            LOGGER.info("Skipped OAuth2 `state` validation, GoCD server < 23.2.0 does not support propagating auth_session parameters");
+            return;
+        }
+
+        String redirectedState = Objects.requireNonNull(requestParameters().get("state"), "OAuth2 state is missing from redirect");
+        String sessionState = Objects.requireNonNull(authSession.get(Constants.AUTH_SESSION_STATE), "OAuth2 state is missing from session");
+        if (!MessageDigest.isEqual(redirectedState.getBytes(), sessionState.getBytes())) {
+            throw new AuthenticationException("Redirected OAuth2 state from GitHub did not match previously generated state stored in session");
+        }
     }
 }

--- a/src/test/java/cd/go/authorization/github/executors/StateGeneratorTest.java
+++ b/src/test/java/cd/go/authorization/github/executors/StateGeneratorTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2023 ThoughtWorks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package cd.go.authorization.github.executors;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class StateGeneratorTest {
+    @Test
+    public void shouldGenerateState() {
+        String state = StateGenerator.generate();
+        assertNotNull(state);
+        assertThat(state, matchesPattern("[A-Za-z0-9_-]{43}="));
+    }
+}

--- a/src/test/java/cd/go/authorization/github/requests/FetchAccessTokenRequestTest.java
+++ b/src/test/java/cd/go/authorization/github/requests/FetchAccessTokenRequestTest.java
@@ -16,6 +16,7 @@
 
 package cd.go.authorization.github.requests;
 
+import cd.go.authorization.github.exceptions.AuthenticationException;
 import cd.go.authorization.github.executors.FetchAccessTokenRequestExecutor;
 import cd.go.authorization.github.models.AuthConfig;
 import com.thoughtworks.go.plugin.api.request.GoPluginApiRequest;
@@ -23,14 +24,59 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
+import java.util.Map;
+
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 public class FetchAccessTokenRequestTest {
+    public static final String WITH_NO_SESSION_RESPONSE = "{\n" +
+            "  \"auth_configs\": [\n" +
+            "    {\n" +
+            "      \"id\": \"github-auth-config\",\n" +
+            "      \"configuration\": {\n" +
+            "        \"GoServerUrl\": \"https://your.go.server.url\",\n" +
+            "        \"ClientId\": \"client-id\",\n" +
+            "        \"ClientSecret\": \"client-secret\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+
+    public static final String WITH_SESSION_STATE_RESPONSE = "{\n" +
+            "  \"auth_configs\": [\n" +
+            "    {\n" +
+            "      \"id\": \"github-auth-config\",\n" +
+            "      \"configuration\": {\n" +
+            "        \"GoServerUrl\": \"https://your.go.server.url\",\n" +
+            "        \"ClientId\": \"client-id\",\n" +
+            "        \"ClientSecret\": \"client-secret\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"auth_session\": {" +
+            "    \"oauth2_state\": \"some-state-value\"" +
+            "  }\n" +
+            "}";
+    public static final String WITH_EMPTY_SESSION_RESPONSE = "{\n" +
+            "  \"auth_configs\": [\n" +
+            "    {\n" +
+            "      \"id\": \"github-auth-config\",\n" +
+            "      \"configuration\": {\n" +
+            "        \"GoServerUrl\": \"https://your.go.server.url\",\n" +
+            "        \"ClientId\": \"client-id\",\n" +
+            "        \"ClientSecret\": \"client-secret\"\n" +
+            "      }\n" +
+            "    }\n" +
+            "  ],\n" +
+            "  \"auth_session\": {}\n" +
+            "}";
     @Mock
     private GoPluginApiRequest apiRequest;
 
@@ -41,29 +87,62 @@ public class FetchAccessTokenRequestTest {
 
     @Test
     public void shouldDeserializeGoPluginApiRequestToFetchAccessTokenRequest() throws Exception {
-        String responseBody = "{\n" +
-                "  \"auth_configs\": [\n" +
-                "    {\n" +
-                "      \"id\": \"github-auth-config\",\n" +
-                "      \"configuration\": {\n" +
-                "        \"GoServerUrl\": \"https://your.go.server.url\",\n" +
-                "        \"ClientId\": \"client-id\",\n" +
-                "        \"ClientSecret\": \"client-secret\"\n" +
-                "      }\n" +
-                "    }\n" +
-                "  ]\n" +
-                "}";
 
-        when(apiRequest.requestBody()).thenReturn(responseBody);
+        when(apiRequest.requestBody()).thenReturn(WITH_NO_SESSION_RESPONSE);
 
         final FetchAccessTokenRequest request = FetchAccessTokenRequest.from(apiRequest);
 
         assertThat(request.authConfigs(), hasSize(1));
+        assertThat(request.authSession(), nullValue());
         assertThat(request.executor(), instanceOf(FetchAccessTokenRequestExecutor.class));
 
         final AuthConfig authConfig = request.authConfigs().get(0);
         assertThat(authConfig.getId(), is("github-auth-config"));
         assertThat(authConfig.gitHubConfiguration().clientId(), is("client-id"));
         assertThat(authConfig.gitHubConfiguration().clientSecret(), is("client-secret"));
+    }
+
+    @Test
+    public void validateStateShouldSucceedWhenNoSessionIsPresent() {
+        final FetchAccessTokenRequest request = new FetchAccessTokenRequest();
+        request.validateState();
+    }
+
+    @Test
+    public void validateStateShouldSucceedWhenSessionStateMatchesRequest() {
+        when(apiRequest.requestBody()).thenReturn(WITH_SESSION_STATE_RESPONSE);
+        when(apiRequest.requestParameters()).thenReturn(Map.of("state", "some-state-value"));
+
+        final FetchAccessTokenRequest request = FetchAccessTokenRequest.from(apiRequest);
+        request.validateState();
+    }
+
+    @Test
+    public void validateStateShouldFailWhenRequestParamIsMissing() {
+        when(apiRequest.requestBody()).thenReturn(WITH_SESSION_STATE_RESPONSE);
+
+        final FetchAccessTokenRequest request = FetchAccessTokenRequest.from(apiRequest);
+        Exception error = assertThrows(NullPointerException.class, request::validateState);
+        assertThat(error.getMessage(), is("OAuth2 state is missing from redirect"));
+    }
+
+    @Test
+    public void validateStateShouldFailWhenSessionStateIsMissing() {
+        when(apiRequest.requestBody()).thenReturn(WITH_EMPTY_SESSION_RESPONSE);
+        when(apiRequest.requestParameters()).thenReturn(Map.of("state", "some-state-value"));
+
+        final FetchAccessTokenRequest request = FetchAccessTokenRequest.from(apiRequest);
+        Exception error = assertThrows(NullPointerException.class, request::validateState);
+        assertThat(error.getMessage(), is("OAuth2 state is missing from session"));
+    }
+
+    @Test
+    public void validateStateShouldFailWhenSessionStateDoesntMatch() {
+        when(apiRequest.requestBody()).thenReturn(WITH_SESSION_STATE_RESPONSE);
+        when(apiRequest.requestParameters()).thenReturn(Map.of("state", "some-other-state-value"));
+
+        final FetchAccessTokenRequest request = FetchAccessTokenRequest.from(apiRequest);
+        Exception error = assertThrows(AuthenticationException.class, request::validateState);
+        assertThat(error.getMessage(), is("Redirected OAuth2 state from GitHub did not match previously generated state stored in session"));
     }
 }


### PR DESCRIPTION
This will require GoCD server 23.2.0 (https://github.com/gocd/gocd/issues/11629 and https://github.com/gocd/gocd/pull/11633) to validate this correctly, but is backward compatible.